### PR TITLE
[feat] 닉네임 중복 확인 구현

### DIFF
--- a/src/api/user/index.ts
+++ b/src/api/user/index.ts
@@ -1,3 +1,5 @@
+import { AxiosError } from 'axios';
+
 import { baseRequest } from '@/api/core';
 import { UserRegister } from '@/api/user/type';
 
@@ -21,3 +23,17 @@ export const postVerifyCode = async (data: { email: string; code: string }) =>
     url: 'api/auth/valid/code',
     data,
   });
+
+export const getVerifyNickname = async (nickname: string) => {
+  try {
+    const response = await baseRequest.request({
+      method: 'GET',
+      url: `api/auth/valid/nickname/${nickname}`,
+    });
+    return response.status;
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return error.response?.status;
+    }
+  }
+};

--- a/src/components/Register/Register.tsx
+++ b/src/components/Register/Register.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   FormControl,
   FormHelperText,
   InputLabel,
@@ -7,8 +8,9 @@ import {
   Stack,
   TextField,
 } from '@mui/material';
-import { Control } from 'react-hook-form';
+import { Control, UseFormSetError, UseFormTrigger } from 'react-hook-form';
 
+import { getVerifyNickname } from '@/api/user';
 import useGetUserForms from '@/components/Register/useGetUserForms';
 import { UserRegisterForm } from '@/pages/auth/register';
 
@@ -25,9 +27,12 @@ const MenuProps = {
 
 interface RegisterProps {
   control: Control<UserRegisterForm>;
+  setValidNickname: (valid: boolean) => void;
+  setError: UseFormSetError<UserRegisterForm>;
+  trigger: UseFormTrigger<UserRegisterForm>;
 }
 
-const Register = ({ control }: RegisterProps) => {
+const Register = ({ control, setValidNickname, setError, trigger }: RegisterProps) => {
   const {
     nickname,
     nicknameState,
@@ -49,16 +54,47 @@ const Register = ({ control }: RegisterProps) => {
       ));
   };
 
+  const handleVerifyNickname = async () => {
+    if (await trigger('nickname')) {
+      const status = await getVerifyNickname(nickname.value);
+
+      let message = '';
+      switch (status) {
+        case 200:
+          message = '사용 가능한 닉네임입니다.';
+          setValidNickname(true);
+          break;
+        case 409:
+          message = '이미 존재하는 닉네임입니다.';
+          break;
+      }
+      setError('nickname', { message });
+    }
+  };
+
   return (
     <Stack spacing={2}>
-      <TextField
-        {...nickname}
-        id='outlined-basic'
-        placeholder='닉네임 2~12자 한글/영문'
-        label='닉네임'
-        variant='outlined'
-        helperText={nicknameState.error && nicknameState.error.message}
-      />
+      <Stack direction='row' spacing={2}>
+        <TextField
+          {...nickname}
+          id='outlined-basic'
+          placeholder='닉네임 2~12자 한글/영문'
+          label='닉네임'
+          variant='outlined'
+          fullWidth
+          onChange={(e) => {
+            nickname.onChange(e.target.value);
+            setValidNickname(false);
+          }}
+          helperText={nicknameState.error && nicknameState.error.message}
+        />
+        <Button
+          variant='contained'
+          sx={{ width: '150px', height: '56px' }}
+          onClick={handleVerifyNickname}>
+          중복확인
+        </Button>
+      </Stack>
       <TextField
         {...password}
         id='outlined-basic'

--- a/src/components/Register/VerifyByEmail.tsx
+++ b/src/components/Register/VerifyByEmail.tsx
@@ -21,7 +21,7 @@ const VerifyByEmail = ({ control, setAuthSuccess, setError }: VerifyEmailProps) 
 
   const handleSendEmail = () => {
     if (/[A-Za-z0-9]+@[a-z]+\.[a-z]{2,3}/.test(email.value)) {
-      setError('email', { message: '' });
+      setError('email', { message: '3분 이내로 인증번호(6자리)를 입력해주세요.' });
       sendEmail.mutate({ email: email.value });
     } else {
       setError('email', { message: '이메일 형식에 맞지 않습니다.' });
@@ -54,11 +54,7 @@ const VerifyByEmail = ({ control, setAuthSuccess, setError }: VerifyEmailProps) 
           label='이메일'
           variant='outlined'
           fullWidth
-          helperText={
-            emailState.error
-              ? emailState.error.message
-              : sendEmail.isSuccess && '3분 이내로 인증번호(6자리)를 입력해주세요.'
-          }
+          helperText={emailState.error && emailState.error.message}
         />
         <Button
           variant='contained'

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -6,6 +6,7 @@ interface StepperProps {
   steps: string[];
   activeStep: number;
   authSuccess: boolean;
+  validNickname: boolean;
   setActiveStep: Dispatch<SetStateAction<number>>;
 }
 
@@ -14,6 +15,7 @@ const HorizontalLinearStepper = ({
   steps,
   activeStep,
   authSuccess,
+  validNickname,
   setActiveStep,
 }: StepperProps) => {
   const [buttonType, setButtonType] = useState<'submit' | 'button'>('button');
@@ -42,7 +44,7 @@ const HorizontalLinearStepper = ({
             <Button
               type={buttonType}
               onClick={!lastStep ? () => setActiveStep((prev) => prev + 1) : undefined}
-              disabled={!authSuccess}
+              disabled={!lastStep ? !authSuccess : !validNickname}
               variant='contained'
               fullWidth>
               {lastStep ? '완료' : '다음'}

--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -20,6 +20,7 @@ const RegisterPage = () => {
   const { mutate: userRegisterMutate } = usePostUserRegister();
   const [activeStep, setActiveStep] = useState(0);
   const [authSuccess, setAuthSuccess] = useState(false);
+  const [validNickname, setValidNickname] = useState(false);
   const methods = useForm<UserRegisterForm>({
     mode: 'onChange',
     defaultValues: {
@@ -31,7 +32,7 @@ const RegisterPage = () => {
       birthYear: '',
     },
   });
-  const { handleSubmit, control, setError } = methods;
+  const { handleSubmit, control, setError, trigger } = methods;
 
   const handleRegister = (data: UserRegisterForm) => {
     const { email, nickname, password, birthYear } = data;
@@ -51,7 +52,8 @@ const RegisterPage = () => {
           steps={steps}
           activeStep={activeStep}
           setActiveStep={setActiveStep}
-          authSuccess={authSuccess}>
+          authSuccess={authSuccess}
+          validNickname={validNickname}>
           {!activeStep ? (
             <VerifyByEmail
               control={control}
@@ -59,7 +61,12 @@ const RegisterPage = () => {
               setError={setError}
             />
           ) : (
-            <Register control={control} />
+            <Register
+              control={control}
+              setValidNickname={setValidNickname}
+              setError={setError}
+              trigger={trigger}
+            />
           )}
         </Stepper>
       </form>

--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -8,7 +8,7 @@ import { UserRegister } from '@/api/user/type';
 import { Register, VerifyByEmail } from '@/components/Register';
 import { Stepper } from '@/components/Stepper';
 
-const steps = ['이메일 인증', '회원가입'];
+const REGISTER_STEP = ['이메일 인증', '회원가입'];
 
 export type UserRegisterForm = UserRegister & {
   code: string;
@@ -49,7 +49,7 @@ const RegisterPage = () => {
       </Typography>
       <form onSubmit={handleSubmit((data) => handleRegister(data))}>
         <Stepper
-          steps={steps}
+          steps={REGISTER_STEP}
           activeStep={activeStep}
           setActiveStep={setActiveStep}
           authSuccess={authSuccess}


### PR DESCRIPTION
## ⛓ 관련 이슈
- close #40 

## 📝 작업 내용
- [x] API 코드 작성
- [x] 닉네임 중복 체크 기능 구현

## 📍 PR Point
- `helper text`에 닉네임이 중복 체크 성공시에도 `setError`를 통해서 사용자 안내 문구를 출력해주고 있는데 올바른 사용 방법이 아닌 것 같아서 나중에 이메일 인증 부분과 함께 수정하겠습니다. 

