### PR TITLE
[feat] 전체 게시글 피드 리스트 기능 1차 구현 (메인 페이지) 

### DIFF
--- a/src/api/hooks/travelogue.ts
+++ b/src/api/hooks/travelogue.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { getRecentTravelogueList } from '@/api/travelogue';
+import { TravelogueFeed } from '@/types/travelogue';
+
+export const useGetRecentTravelogue = () => {
+  return useQuery<TravelogueFeed[], AxiosError>({
+    queryKey: ['RecentTravelogueData'],
+    queryFn: () => getRecentTravelogueList(),
+  });
+};

--- a/src/api/travelogue/index.ts
+++ b/src/api/travelogue/index.ts
@@ -1,0 +1,11 @@
+import { baseRequest } from '@/api/core';
+import { TravelogueFeed } from '@/types/travelogue';
+
+export const getRecentTravelogueList = async (page = 1): Promise<TravelogueFeed[]> => {
+  const response = await baseRequest({
+    method: 'GET',
+    url: `api/travelogues?&page=${page}`,
+  });
+
+  return response.data.content;
+};

--- a/src/components/CreatePost/StepperButton.tsx
+++ b/src/components/CreatePost/StepperButton.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction } from 'react';
 import { UseFormHandleSubmit } from 'react-hook-form';
 
-import { createPost } from '@/api/post';
+import { createPost } from '@/api/post/createPost';
 import { CreatePost } from '@/types/CreatePost';
 
 interface StepperButtonProps {

--- a/src/components/Travelogue/TravelogueFeed.tsx
+++ b/src/components/Travelogue/TravelogueFeed.tsx
@@ -5,8 +5,6 @@ import { FeedContent, FeedHeader, FeedImage } from '@/components/Travelogue';
 import { TravelogueFeed as TravelogueFeedType } from './type';
 
 const TravelogueFeed = ({ data }: { data: TravelogueFeedType }) => {
-  console.log('hello');
-
   return (
     <Stack spacing={1.5} sx={{ maxWidth: '90%', height: 300, margin: '0 auto', pb: 3 }}>
       <FeedHeader

--- a/src/components/Travelogue/TravelogueFeed.tsx
+++ b/src/components/Travelogue/TravelogueFeed.tsx
@@ -2,34 +2,24 @@ import { Stack } from '@mui/material';
 
 import { FeedContent, FeedHeader, FeedImage } from '@/components/Travelogue';
 
-const DUMMY_DATA = {
-  title: '일본 오사카 여행기',
-  nights: 3,
-  days: 4,
-  totalCost: 400000,
-  country: '일본',
-  thumbnail:
-    'https://firebasestorage.googleapis.com/v0/b/junglee-habit.appspot.com/o/challanges%2FIMQBHIsoNIMngElt9sRf%2F0aWv3BRsSVJMcz5yU4uS?alt=media&token=6dce71b4-e11f-4fa3-9b5a-fab54bb100d8',
-  member: {
-    nickname: 'moen',
-    profileImageUrl: 'https://mui.com/static/images/avatar/3.jpg',
-  },
-};
+import { TravelogueFeed as TravelogueFeedType } from './type';
 
-const TravelogueFeed = () => {
+const TravelogueFeed = ({ data }: { data: TravelogueFeedType }) => {
+  console.log('hello');
+
   return (
-    <Stack spacing={1.5} sx={{ maxWidth: '90%', height: 300 }}>
+    <Stack spacing={1.5} sx={{ maxWidth: '90%', height: 300, margin: '0 auto', pb: 3 }}>
       <FeedHeader
-        profileImageUrl={DUMMY_DATA.member.profileImageUrl}
-        nickname={DUMMY_DATA.member.nickname}
-        country={DUMMY_DATA.country}
+        profileImageUrl={data.member.profileImageUrl}
+        nickname={data.member.nickname}
+        country={data.country}
       />
-      <FeedImage thumbnailURL={DUMMY_DATA.thumbnail} ImageAlt={DUMMY_DATA.title} />
+      <FeedImage thumbnailURL={data.thumbnail} ImageAlt={data.title} />
       <FeedContent
-        title={DUMMY_DATA.title}
-        totalCost={DUMMY_DATA.totalCost}
-        nights={DUMMY_DATA.nights}
-        days={DUMMY_DATA.days}
+        title={data.title}
+        totalCost={data.totalCost}
+        nights={data.nights}
+        days={data.days}
       />
     </Stack>
   );

--- a/src/components/Travelogue/TravelogueList.tsx
+++ b/src/components/Travelogue/TravelogueList.tsx
@@ -17,7 +17,7 @@ const TravelogueList = () => {
   return (
     <Stack>
       {travelogues.map((travelogue) => {
-        return <TravelogueFeed key={travelogue.id} data={travelogue} />;
+        return <TravelogueFeed key={String(travelogue.travelogueId)} data={travelogue} />;
       })}
     </Stack>
   );

--- a/src/components/Travelogue/TravelogueList.tsx
+++ b/src/components/Travelogue/TravelogueList.tsx
@@ -1,0 +1,26 @@
+import { Stack } from '@mui/material';
+import React from 'react';
+
+import { useGetRecentTravelogue } from '@/api/hooks/travelogue';
+
+import TravelogueFeed from './TravelogueFeed';
+
+const TravelogueList = () => {
+  const { data: travelogues } = useGetRecentTravelogue();
+
+  console.log(travelogues);
+
+  if (!travelogues || travelogues.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack>
+      {travelogues.map((travelogue) => {
+        return <TravelogueFeed key={travelogue.id} data={travelogue} />;
+      })}
+    </Stack>
+  );
+};
+
+export default TravelogueList;

--- a/src/components/Travelogue/TravelogueList.tsx
+++ b/src/components/Travelogue/TravelogueList.tsx
@@ -2,6 +2,7 @@ import { Stack } from '@mui/material';
 import React from 'react';
 
 import { useGetRecentTravelogue } from '@/api/hooks/travelogue';
+import { TemporaryButton } from '@/components/common';
 
 import TravelogueFeed from './TravelogueFeed';
 
@@ -15,7 +16,8 @@ const TravelogueList = () => {
   }
 
   return (
-    <Stack>
+    <Stack spacing={1} alignItems='center'>
+      <TemporaryButton />
       {travelogues.map((travelogue) => {
         return <TravelogueFeed key={String(travelogue.travelogueId)} data={travelogue} />;
       })}

--- a/src/components/Travelogue/index.ts
+++ b/src/components/Travelogue/index.ts
@@ -3,3 +3,4 @@ export { default as FeedContent } from './FeedContent';
 export { default as FeedHeader } from './FeedHeader';
 export { default as FeedImage } from './FeedImage';
 export { default as TravelogueFeed } from './TravelogueFeed';
+export { default as TravelogueList } from './TravelogueList';

--- a/src/components/common/TemporaryButton.tsx
+++ b/src/components/common/TemporaryButton.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { Box, Stack } from '@mui/material';
+import { styled as muiStyled } from '@mui/material/styles';
+import Link from 'next/link';
+
+const TemporaryButton = () => {
+  return (
+    <Stack spacing={4} direction='row' justifyContent='space-between'>
+      <CustomBox>
+        <Link href='/auth/login'>
+          <CustomLink>로그인</CustomLink>
+        </Link>
+      </CustomBox>
+      <CustomBox>
+        <Link href='/post/1'>
+          <CustomLink>피드작성</CustomLink>
+        </Link>
+      </CustomBox>
+    </Stack>
+  );
+};
+
+export default TemporaryButton;
+
+const CustomBox = muiStyled(Box)(({ theme }) => ({
+  border: `1px solid ${theme.palette.blue040.main}`,
+  borderRadius: '5px',
+  backgroundColor: theme.palette.blue050.main,
+  color: theme.palette.white.main,
+}));
+
+const CustomLink = styled.a`
+  display: inline-block;
+  padding: 10px;
+  color: #ffffff;
+  font-weight: bold;
+`;

--- a/src/components/common/TemporaryButton.tsx
+++ b/src/components/common/TemporaryButton.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import { Box, Stack } from '@mui/material';
 import { styled as muiStyled } from '@mui/material/styles';
 import Link from 'next/link';
@@ -7,14 +6,10 @@ const TemporaryButton = () => {
   return (
     <Stack spacing={4} direction='row' justifyContent='space-between'>
       <CustomBox>
-        <Link href='/auth/login'>
-          <CustomLink>로그인</CustomLink>
-        </Link>
+        <CustomLink href='/auth/login'>로그인</CustomLink>
       </CustomBox>
       <CustomBox>
-        <Link href='/post/1'>
-          <CustomLink>피드작성</CustomLink>
-        </Link>
+        <CustomLink href='/post/1'>피드작성</CustomLink>
       </CustomBox>
     </Stack>
   );
@@ -29,9 +24,9 @@ const CustomBox = muiStyled(Box)(({ theme }) => ({
   color: theme.palette.white.main,
 }));
 
-const CustomLink = styled.a`
-  display: inline-block;
-  padding: 10px;
-  color: #ffffff;
-  font-weight: bold;
-`;
+const CustomLink = muiStyled(Link)(({ theme }) => ({
+  display: 'inline-block',
+  padding: '10px',
+  color: theme.palette.white.main,
+  fontWeight: 'bold',
+}));

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,4 +1,5 @@
 export { default as CommonInput } from './CommonInput';
 export { default as Row } from './Row';
 export { default as SubTitle } from './SubTitle';
+export { default as TemporaryButton } from './TemporaryButton';
 export { default as Title } from './Titlte';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 
-import { TravelogueFeed } from '@/components/Travelogue';
+import { TravelogueList } from '@/components/Travelogue';
 
 export default function Home() {
   return (
@@ -12,7 +12,7 @@ export default function Home() {
         <link rel='icon' href='/favicon.ico' />
       </Head>
       <main>
-        <TravelogueFeed />
+        <TravelogueList />
       </main>
     </>
   );

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -149,4 +149,18 @@ const style = css`
     border-collapse: collapse;
     border-spacing: 0;
   }
+
+  /* 데모 데이를 위한 임시 스타일 */
+  a:link {
+    color: #333;
+    text-decoration: none;
+  }
+  a:visited {
+    color: #333;
+    text-decoration: none;
+  }
+  a:hover {
+    color: inherit;
+    text-decoration: none;
+  }
 `;


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #47 

## 📝 작업 내용

- 게시글 목록 조회 API 연결하기
- API로 받은 데이터를 통한 UI 업데이트

## 📍 PR Point

- `TravelogueFeed` 공통 타입으로 분리하는 작업이 필요합니다.
- 무한 스크롤 기능을 추가해야 합니다.
- 스와이프 슬라이드 기능을 추가해야 합니다.
- Concurrent UI Pattern 을 고민해봐야 합니다.

## 📷 스크린샷

https://user-images.githubusercontent.com/57402711/222194524-f1cc34e3-b515-4078-870c-7c6ca7ff50f1.mov
