### PR TITLE
[fix]: 게시글 목록 api 관련 데이터 타입 경로 변경으로 인한 경로 에러 수정

### DIFF
--- a/src/components/Travelogue/FeedContent.tsx
+++ b/src/components/Travelogue/FeedContent.tsx
@@ -7,10 +7,12 @@ import { useState } from 'react';
 
 import { Row } from '@/components/common';
 import { FeedChip } from '@/components/Travelogue';
+import { TravelogueFeedType } from '@/types/travelogue';
 
-import { TravelogueFeed } from './type';
-
-type FeedContentProps = Pick<TravelogueFeed, 'title' | 'nights' | 'days' | 'totalCost'>;
+type FeedContentProps = Pick<
+  TravelogueFeedType,
+  'title' | 'nights' | 'days' | 'totalCost'
+>;
 
 const FeedContent = ({ title, nights, days, totalCost }: FeedContentProps) => {
   const [isFavorite, setIsFavorite] = useState(false);

--- a/src/components/Travelogue/FeedHeader.tsx
+++ b/src/components/Travelogue/FeedHeader.tsx
@@ -1,10 +1,10 @@
 import { Person, Room as Marker } from '@mui/icons-material';
 import { Avatar, Stack, Typography } from '@mui/material';
 
-import { TravelogueFeed } from './type';
+import { TravelogueFeedType } from '@/types/travelogue';
 
-type FeedHeaderProps = TravelogueFeed['member'] & {
-  country: TravelogueFeed['country'];
+type FeedHeaderProps = TravelogueFeedType['member'] & {
+  country: TravelogueFeedType['country'];
 };
 
 const FeedHeader = ({

--- a/src/components/Travelogue/FeedImage.tsx
+++ b/src/components/Travelogue/FeedImage.tsx
@@ -1,14 +1,14 @@
 import { Box } from '@mui/material';
 import Image from 'next/image';
 
-import { TravelogueFeed } from './type';
+import { TravelogueFeedType } from '@/types/travelogue';
 
-interface FeedImageProps {
-  thumbnailURL: TravelogueFeed['thumbnail'];
-  ImageAlt: TravelogueFeed['title'];
+interface TravelogueFeedProps {
+  thumbnailURL: TravelogueFeedType['thumbnail'];
+  ImageAlt: TravelogueFeedType['title'];
 }
 
-const FeedImage = ({ thumbnailURL, ImageAlt }: FeedImageProps) => {
+const FeedImage = ({ thumbnailURL, ImageAlt }: TravelogueFeedProps) => {
   return (
     <Box sx={boxStyle}>
       <Image src={thumbnailURL} fill alt={ImageAlt} />

--- a/src/components/Travelogue/TravelogueFeed.tsx
+++ b/src/components/Travelogue/TravelogueFeed.tsx
@@ -1,8 +1,7 @@
 import { Stack } from '@mui/material';
 
 import { FeedContent, FeedHeader, FeedImage } from '@/components/Travelogue';
-
-import { TravelogueFeed as TravelogueFeedType } from './type';
+import { TravelogueFeedType } from '@/types/travelogue';
 
 const TravelogueFeed = ({ data }: { data: TravelogueFeedType }) => {
   return (

--- a/src/types/travelogue.ts
+++ b/src/types/travelogue.ts
@@ -1,4 +1,4 @@
-export interface TravelogueFeed {
+export interface TravelogueFeedType {
   title: string;
   country: string;
   thumbnail: string;


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #60 

## 📝 작업 내용

- `@/components/Travelogue/type.ts` 파일 삭제
- `@/components/Travelogue/type.ts` 파일에 의존하는 타입 `@/types/travelogue.ts` 파일로 변경

## 📍 PR Point
- Travelogu(게시글 피드)에 관련된 타입을 수정했습니다. 타입을 중점으로 리뷰 부탁드립니다 👍👍