### PR TITLE
[feat] 인기 게시글 목록 캐러셀 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "next": "13.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "use-places-autocomplete": "^4.0.0",
     "react-hook-form": "^7.43.2",
-    "recoil": "^0.7.6"
+    "recoil": "^0.7.6",
+    "use-places-autocomplete": "^4.0.0"
   },
   "devDependencies": {
     "@stylelint/postcss-css-in-js": "^0.38.0",
@@ -34,6 +34,7 @@
     "@types/node": "18.14.0",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",
+    "@types/react-slick": "^0.23.10",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "axios": "^1.3.4",
@@ -48,6 +49,8 @@
     "postcss-syntax": "^0.36.2",
     "prettier": "^2.8.4",
     "react-hook-form": "^7.43.2",
+    "react-slick": "^0.29.0",
+    "slick-carousel": "^1.8.1",
     "stylelint": "^14.16.1",
     "stylelint-config-prettier": "^9.0.4",
     "stylelint-config-rational-order": "^0.1.2",

--- a/src/api/hooks/travelogue.ts
+++ b/src/api/hooks/travelogue.ts
@@ -6,7 +6,7 @@ import { TravelogueFeedType } from '@/types/travelogue';
 
 export const useGetRecentTravelogue = () => {
   return useQuery<TravelogueFeedType[], AxiosError>({
-    queryKey: ['RecentTravelogueData'],
+    queryKey: ['RECENT_TRAVELOGUES'],
     queryFn: () => getRecentTravelogueList(),
   });
 };

--- a/src/api/hooks/travelogue.ts
+++ b/src/api/hooks/travelogue.ts
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { getRecentTravelogueList } from '@/api/travelogue';
-import { TravelogueFeed } from '@/types/travelogue';
+import { TravelogueFeedType } from '@/types/travelogue';
 
 export const useGetRecentTravelogue = () => {
-  return useQuery<TravelogueFeed[], AxiosError>({
+  return useQuery<TravelogueFeedType[], AxiosError>({
     queryKey: ['RecentTravelogueData'],
     queryFn: () => getRecentTravelogueList(),
   });

--- a/src/api/travelogue/index.ts
+++ b/src/api/travelogue/index.ts
@@ -1,7 +1,9 @@
 import { baseRequest } from '@/api/core';
-import { TravelogueFeed } from '@/types/travelogue';
+import { TravelogueFeedType } from '@/types/travelogue';
 
-export const getRecentTravelogueList = async (page = 1): Promise<TravelogueFeed[]> => {
+export const getRecentTravelogueList = async (
+  page = 1,
+): Promise<TravelogueFeedType[]> => {
   const response = await baseRequest({
     method: 'GET',
     url: `api/travelogues?&page=${page}`,

--- a/src/components/Travelogue/FeedImage.tsx
+++ b/src/components/Travelogue/FeedImage.tsx
@@ -11,7 +11,7 @@ interface TravelogueFeedProps {
 const FeedImage = ({ thumbnailURL, ImageAlt }: TravelogueFeedProps) => {
   return (
     <Box sx={boxStyle}>
-      <Image src={thumbnailURL} fill alt={ImageAlt} />
+      <Image src={thumbnailURL} fill alt={ImageAlt} sizes='300px' priority />
     </Box>
   );
 };

--- a/src/components/Travelogue/PopularFeed/PopularFeed.tsx
+++ b/src/components/Travelogue/PopularFeed/PopularFeed.tsx
@@ -7,7 +7,7 @@ import { useGetRecentTravelogue } from '@/api/hooks/travelogue';
 import { TravelogueFeed } from '@/components/Travelogue';
 
 const PopularFeed = () => {
-  const { data: travelogues } = useGetRecentTravelogue();
+  const { data: popularTravelogues } = useGetRecentTravelogue();
 
   const settings = {
     dots: true,
@@ -17,13 +17,13 @@ const PopularFeed = () => {
     slidesToScroll: 1,
   };
 
-  if (!travelogues || travelogues.length === 0) {
+  if (!popularTravelogues || popularTravelogues.length === 0) {
     return null;
   }
 
   return (
     <Slider {...settings}>
-      {travelogues.map((travelogue) => {
+      {popularTravelogues.map((travelogue) => {
         return <TravelogueFeed key={String(travelogue.travelogueId)} data={travelogue} />;
       })}
     </Slider>

--- a/src/components/Travelogue/PopularFeed/PopularFeed.tsx
+++ b/src/components/Travelogue/PopularFeed/PopularFeed.tsx
@@ -1,0 +1,34 @@
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+
+import Slider from 'react-slick';
+
+import { useGetRecentTravelogue } from '@/api/hooks/travelogue';
+
+import TravelogueFeed from '../TravelogueFeed';
+
+const PopularFeed = () => {
+  const { data: travelogues } = useGetRecentTravelogue();
+
+  const settings = {
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+  };
+
+  if (!travelogues || travelogues.length === 0) {
+    return null;
+  }
+
+  return (
+    <Slider {...settings}>
+      {travelogues.map((travelogue) => {
+        return <TravelogueFeed key={String(travelogue.travelogueId)} data={travelogue} />;
+      })}
+    </Slider>
+  );
+};
+
+export default PopularFeed;

--- a/src/components/Travelogue/PopularFeed/PopularFeed.tsx
+++ b/src/components/Travelogue/PopularFeed/PopularFeed.tsx
@@ -4,8 +4,7 @@ import 'slick-carousel/slick/slick-theme.css';
 import Slider from 'react-slick';
 
 import { useGetRecentTravelogue } from '@/api/hooks/travelogue';
-
-import TravelogueFeed from '../TravelogueFeed';
+import { TravelogueFeed } from '@/components/Travelogue';
 
 const PopularFeed = () => {
   const { data: travelogues } = useGetRecentTravelogue();

--- a/src/components/Travelogue/PopularFeed/index.ts
+++ b/src/components/Travelogue/PopularFeed/index.ts
@@ -1,0 +1,1 @@
+export { default as PopularFeed } from './PopularFeed';

--- a/src/components/Travelogue/TravelogueFeed.tsx
+++ b/src/components/Travelogue/TravelogueFeed.tsx
@@ -1,11 +1,22 @@
 import { Stack } from '@mui/material';
+import { useRouter } from 'next/router';
 
 import { FeedContent, FeedHeader, FeedImage } from '@/components/Travelogue';
 import { TravelogueFeedType } from '@/types/travelogue';
 
 const TravelogueFeed = ({ data }: { data: TravelogueFeedType }) => {
+  const router = useRouter();
+
   return (
-    <Stack spacing={1.5} sx={{ maxWidth: '90%', height: 300, margin: '0 auto', pb: 3 }}>
+    <Stack
+      spacing={1.5}
+      sx={{ maxWidth: '90%', height: 300, margin: '0 auto', pb: 3, cursor: 'pointer' }}
+      onClick={() =>
+        router.push({
+          pathname: '/detail',
+          query: { travelogueId: data.travelogueId },
+        })
+      }>
       <FeedHeader
         profileImageUrl={data.member.profileImageUrl}
         nickname={data.member.nickname}

--- a/src/pages/detail/index.tsx
+++ b/src/pages/detail/index.tsx
@@ -1,0 +1,14 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+
+const Detail = () => {
+  const {
+    query: { travelogueId },
+  } = useRouter();
+
+  console.log(travelogueId, typeof travelogueId);
+
+  return <div>Detail</div>;
+};
+
+export default Detail;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 
-import { TravelogueList } from '@/components/Travelogue';
+import { PopularFeed } from '@/components/Travelogue/PopularFeed';
 
 export default function Home() {
   return (
@@ -12,7 +12,7 @@ export default function Home() {
         <link rel='icon' href='/favicon.ico' />
       </Head>
       <main>
-        <TravelogueList />
+        <PopularFeed />
       </main>
     </>
   );

--- a/src/types/travelogue.ts
+++ b/src/types/travelogue.ts
@@ -1,4 +1,5 @@
 export interface TravelogueFeedType {
+  travelogueId: number;
   title: string;
   country: string;
   thumbnail: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-slick@^0.23.10":
+  version "0.23.10"
+  resolved "https://registry.yarnpkg.com/@types/react-slick/-/react-slick-0.23.10.tgz#56126e6e4e95cdce7771535b2811c2c1931a7caa"
+  integrity sha512-ZiqdencANDZy6sWOWJ54LDvebuXFEhDlHtXU9FFipQR2BcYU2QJxZhvJPW6YK7cocibUiNn+YvDTbt1HtCIBVA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.5":
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
@@ -1487,6 +1494,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -1889,6 +1901,11 @@ enhanced-resolve@^5.10.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+enquire.js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/enquire.js/-/enquire.js-2.1.6.tgz#3e8780c9b8b835084c3f60e166dbc3c2a3c89814"
+  integrity sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==
 
 entities@^1.1.1:
   version "1.1.2"
@@ -3388,6 +3405,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json2mq@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  integrity sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==
+  dependencies:
+    string-convert "^0.2.0"
+
 json5@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
@@ -3546,6 +3570,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -4459,6 +4488,17 @@ react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-slick@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.29.0.tgz#0bed5ea42bf75a23d40c0259b828ed27627b51bb"
+  integrity sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==
+  dependencies:
+    classnames "^2.2.5"
+    enquire.js "^2.1.6"
+    json2mq "^0.2.0"
+    lodash.debounce "^4.0.8"
+    resize-observer-polyfill "^1.5.0"
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
@@ -4640,6 +4680,11 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -4866,6 +4911,11 @@ slice-ansi@^5.0.0:
     ansi-styles "^6.0.0"
     is-fullwidth-code-point "^4.0.0"
 
+slick-carousel@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.8.1.tgz#a4bfb29014887bb66ce528b90bd0cda262cc8f8d"
+  integrity sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -4994,6 +5044,11 @@ string-argv@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
+  integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
 string-width@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #57 

## 📝 작업 내용
- react-slick 라이브러리 설치
- 게시글 목록 캐러셀 기능 구현하기
- 게시글 목록 피드에서 게시글 상세로 이동하는 라우터 구현
    - 게시글 이동 라우터 이벤트 핸들러 구현
    - 게시글 이동 라우터 연결하기
    - 상세 페이지 api를 호출하기 위한 query 데이터를 담아서 라우팅 하는 로직 구현


## 📍 PR Point
- 처음에는 Swiper.js 라이브러리를 사용하여 캐러셀을 구현하려고 했지만 Swiper.js와 CSS in JS 호환성이 좋지 않아서 스타일 커스텀이 가장 간편하고 용량이 가벼운 react-slick 라이브러리를 선택하게 되었습니다. 
- react-slick 라이브러리의 문제점으로는 내부적으로 jQuery 라이브러리를 의존하고 있어서 추후 직접 구현하는 방향으로 변경할 예정입니다.
- `nvm use` -> `yarn` -> `yarn dev`를 실행해주세요 👍👍


## 📷 스크린샷

https://user-images.githubusercontent.com/57402711/222954189-41cd1dec-a180-4678-8f46-2b3fd1f335a9.mov


