### PR TITLE
[design] 로그인 유도 모달창 디자인

### DIFF
--- a/src/components/common/CommonButton.tsx
+++ b/src/components/common/CommonButton.tsx
@@ -7,9 +7,13 @@ interface CommonButtonProps {
   handleClick?: () => void;
 }
 
-const CommonButton = ({ content, customStyle }: CommonButtonProps) => {
+const CommonButton = ({ content, customStyle, handleClick }: CommonButtonProps) => {
   return (
-    <Button type='button' variant='contained' sx={{ ...buttonStyle, ...customStyle }}>
+    <Button
+      onClick={handleClick && handleClick}
+      type='button'
+      variant='contained'
+      sx={{ ...buttonStyle, ...customStyle }}>
       {content}
     </Button>
   );

--- a/src/components/common/SigninLeadModal.tsx
+++ b/src/components/common/SigninLeadModal.tsx
@@ -1,0 +1,47 @@
+import { Error as ErrorIcon } from '@mui/icons-material';
+import { DialogContentText, Typography } from '@mui/material';
+import { Dialog, DialogContent, DialogTitle } from '@mui/material';
+
+import { flexCenterStyle } from '@/styles/CenterStyle';
+
+interface SigninLeadModalProps {
+  open: boolean;
+  handleClickClose: () => void;
+}
+
+const SigninLeadModal = ({ open, handleClickClose }: SigninLeadModalProps) => {
+  return (
+    <Dialog open={open} onClose={handleClickClose}>
+      <DialogTitle className='readable-hidden'>로그인 유도 모달</DialogTitle>
+
+      <DialogContent
+        sx={{
+          ...flexCenterStyle,
+          flexDirection: 'column',
+          minWidth: 300,
+          minHeight: 125,
+          p: 0,
+        }}>
+        <DialogContentText sx={{ py: 3 }}>
+          <ErrorIcon
+            sx={{
+              ...flexCenterStyle,
+              fontSize: '3.5rem',
+              color: 'blue040.main',
+            }}
+          />
+        </DialogContentText>
+        <DialogContentText sx={modalTextStyle}>
+          <Typography component='span' sx={{ ...modalTextStyle, color: 'blue050.main' }}>
+            로그인
+          </Typography>
+          &nbsp;하시겠습니까?
+        </DialogContentText>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SigninLeadModal;
+
+const modalTextStyle = { fontSize: '1.25rem', fontWeight: 'bold' };

--- a/src/components/common/SigninLeadModal.tsx
+++ b/src/components/common/SigninLeadModal.tsx
@@ -1,7 +1,9 @@
 import { Error as ErrorIcon } from '@mui/icons-material';
-import { DialogContentText, Typography } from '@mui/material';
+import { DialogActions, DialogContentText, Typography } from '@mui/material';
 import { Dialog, DialogContent, DialogTitle } from '@mui/material';
+import { useRouter } from 'next/router';
 
+import { CommonButton } from '@/components/common';
 import { flexCenterStyle } from '@/styles/CenterStyle';
 
 interface SigninLeadModalProps {
@@ -10,8 +12,13 @@ interface SigninLeadModalProps {
 }
 
 const SigninLeadModal = ({ open, handleClickClose }: SigninLeadModalProps) => {
+  const router = useRouter();
+
   return (
-    <Dialog open={open} onClose={handleClickClose}>
+    <Dialog
+      open={open}
+      onClose={handleClickClose}
+      PaperProps={{ style: { borderRadius: 12 } }}>
       <DialogTitle className='readable-hidden'>로그인 유도 모달</DialogTitle>
 
       <DialogContent
@@ -21,6 +28,7 @@ const SigninLeadModal = ({ open, handleClickClose }: SigninLeadModalProps) => {
           minWidth: 300,
           minHeight: 125,
           p: 0,
+          borderRadius: 20,
         }}>
         <DialogContentText sx={{ py: 3 }}>
           <ErrorIcon
@@ -38,6 +46,18 @@ const SigninLeadModal = ({ open, handleClickClose }: SigninLeadModalProps) => {
           &nbsp;하시겠습니까?
         </DialogContentText>
       </DialogContent>
+      <DialogActions sx={{ mb: 1, px: 4, py: 2.5 }}>
+        <CommonButton
+          content='로그인'
+          customStyle={buttonStyle}
+          handleClick={() => router.push('/auth/login')}
+        />
+        <CommonButton
+          content='취소'
+          customStyle={{ ...buttonStyle, bgcolor: 'gray010.main', color: 'dark.main' }}
+          handleClick={() => handleClickClose()}
+        />
+      </DialogActions>
     </Dialog>
   );
 };
@@ -45,3 +65,4 @@ const SigninLeadModal = ({ open, handleClickClose }: SigninLeadModalProps) => {
 export default SigninLeadModal;
 
 const modalTextStyle = { fontSize: '1.25rem', fontWeight: 'bold' };
+const buttonStyle = { height: '50px', m: 0 };

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -6,6 +6,7 @@ export { default as FileInput } from './FileInput';
 export { default as FilterButton } from './FilterButton';
 export { default as ProfileAvatar } from './ProfileAvatar';
 export { default as Row } from './Row';
+export { default as SigninLeadModal } from './SigninLeadModal';
 export { default as SubTitle } from './SubTitle';
 export { default as TemporaryButton } from './TemporaryButton';
 export { default as Title } from './Titlte';

--- a/src/styles/CenterStyle.ts
+++ b/src/styles/CenterStyle.ts
@@ -2,3 +2,9 @@ export const CenterStyle = {
   display: 'flex',
   justifyContent: 'center',
 };
+
+export const flexCenterStyle = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+};

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -174,4 +174,12 @@ const style = css`
   .ql-editor {
     word-spacing: 0;
   }
+
+  .readable-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+  }
 `;


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #69 

## 📝 작업 내용

- mui modal 컴포넌트를 사용해서 로그인 유도 모달 레이아웃 구현
- modal 컴포넌트에서 사용되는 공통 버튼 @/components/common/CommonButton.tsx` 재사용

## 📷 스크린샷

<img src="https://user-images.githubusercontent.com/57402711/224325252-ac55c2e0-936f-41be-a19c-3876a93578fa.jpg" width="30%" />



