### PR TITLE
[feat] 서브 트래블로그 지역 자동 완성 구현

### DIFF
--- a/src/components/SearchModal/AutoComplete.tsx
+++ b/src/components/SearchModal/AutoComplete.tsx
@@ -1,6 +1,8 @@
 import { useLoadScript } from '@react-google-maps/api';
 import { ReactNode } from 'react';
 
+import Spinner from '@/components/common/Spinner';
+
 const libraries: (
   | 'drawing'
   | 'geometry'
@@ -19,7 +21,7 @@ const AutoComplete = ({ children }: AutoCompleteProps) => {
     libraries,
   });
 
-  if (!isLoaded) return <div>Loading...</div>;
+  if (!isLoaded) return <Spinner isLoading={isLoaded} />;
   return <>{children}</>;
 };
 

--- a/src/components/SearchModal/AutoComplete.tsx
+++ b/src/components/SearchModal/AutoComplete.tsx
@@ -1,6 +1,5 @@
 import { useLoadScript } from '@react-google-maps/api';
-
-import { PlacesAutocomplete } from './';
+import { ReactNode } from 'react';
 
 const libraries: (
   | 'drawing'
@@ -10,14 +9,18 @@ const libraries: (
   | 'visualization'
 )[] = ['places'];
 
-const AutoComplete = () => {
+interface AutoCompleteProps {
+  children: ReactNode;
+}
+
+const AutoComplete = ({ children }: AutoCompleteProps) => {
   const { isLoaded } = useLoadScript({
     googleMapsApiKey: process.env.NEXT_PUBLIC_MAPS_KEY as string,
     libraries,
   });
 
   if (!isLoaded) return <div>Loading...</div>;
-  return <PlacesAutocomplete />;
+  return <>{children}</>;
 };
 
 export default AutoComplete;

--- a/src/components/SearchModal/AutoCompleteList.tsx
+++ b/src/components/SearchModal/AutoCompleteList.tsx
@@ -1,0 +1,59 @@
+import { LocationOn } from '@mui/icons-material';
+import { Box, Stack, styled, Typography } from '@mui/material';
+import { ComboboxList, ComboboxOption, ComboboxPopover } from '@reach/combobox';
+import { Suggestions } from 'use-places-autocomplete';
+
+interface AutoCompleteListProps {
+  suggestions: Suggestions;
+}
+
+const AutoCompleteList = ({ suggestions }: AutoCompleteListProps) => {
+  const { status, data } = suggestions;
+
+  return (
+    <PopOver>
+      <ComboboxList
+        style={{ listStyle: 'none', margin: 0, padding: 0, userSelect: 'none' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', flexDirection: 'column' }}>
+          {status === 'OK' &&
+            data.map(({ place_id, structured_formatting }) => (
+              <Options key={place_id} value={structured_formatting.main_text}>
+                <Box key={place_id} sx={{ display: 'flex', mt: '1rem' }}>
+                  <LocationOn />
+                  <Stack sx={{ wordWrap: 'break-word' }}>
+                    <Typography variant='body2' color='black.main' fontSize='1rem'>
+                      {structured_formatting.main_text}
+                    </Typography>
+                    <Typography variant='body2' color='primary' fontSize='0.8rem'>
+                      {structured_formatting.secondary_text}
+                    </Typography>
+                  </Stack>
+                </Box>
+              </Options>
+            ))}
+        </Box>
+      </ComboboxList>
+    </PopOver>
+  );
+};
+
+export default AutoCompleteList;
+
+const PopOver = styled(ComboboxPopover)(({ theme }) => ({
+  borderRadius: '0 0 10px 10px',
+  background: theme.palette.blue010.main,
+  zIndex: 5000,
+}));
+
+const Options = styled(ComboboxOption)(({ theme }) => ({
+  cursor: 'pointer',
+  margin: 0,
+  padding: '0 0.25rem',
+
+  '&:hover': {
+    background: theme.palette.gray030.main,
+    '&:last-child': {
+      borderRadius: '0 0 10px 10px',
+    },
+  },
+}));

--- a/src/components/SearchModal/PlacesAutocomplete.tsx
+++ b/src/components/SearchModal/PlacesAutocomplete.tsx
@@ -1,18 +1,12 @@
-import { LocationOn } from '@mui/icons-material';
 import { Search as SearchIcon } from '@mui/icons-material';
-import { Box, IconButton, Stack, styled, Typography } from '@mui/material';
-import {
-  Combobox,
-  ComboboxInput,
-  ComboboxList,
-  ComboboxOption,
-  ComboboxPopover,
-} from '@reach/combobox';
+import { IconButton, Stack, styled } from '@mui/material';
+import { Combobox, ComboboxInput } from '@reach/combobox';
 import { useRouter } from 'next/router';
 import { KeyboardEvent } from 'react';
 import { useSetRecoilState } from 'recoil';
-import usePlacesAutocomplete from 'use-places-autocomplete';
 
+import AutoCompleteList from '@/components/SearchModal/AutoCompleteList';
+import useAutoComplete from '@/hooks/useAutoComplete';
 import { isHeaderOpenState } from '@/recoil';
 
 const PLACEHOLDER_SEARCH = '도시 또는 키워드를 입력해주세요';
@@ -20,18 +14,7 @@ const PLACEHOLDER_SEARCH = '도시 또는 키워드를 입력해주세요';
 const PlacesAutocomplete = () => {
   const setIsOpen = useSetRecoilState(isHeaderOpenState);
   const router = useRouter();
-  const {
-    ready,
-    value,
-    setValue,
-    suggestions: { status, data },
-    clearSuggestions,
-  } = usePlacesAutocomplete();
-
-  const handleSelect = async (address: string) => {
-    setValue(address, false);
-    clearSuggestions();
-  };
+  const { ready, value, setValue, suggestions, handleSelect } = useAutoComplete();
 
   const handleSubmit = () => {
     setIsOpen(false);
@@ -62,30 +45,7 @@ const PlacesAutocomplete = () => {
           <SearchIcon color='white' />
         </IconButton>
       </Stack>
-      <PopOver>
-        <ComboboxList
-          style={{ listStyle: 'none', margin: 0, padding: 0, userSelect: 'none' }}>
-          <Box
-            sx={{ display: 'flex', justifyContent: 'center', flexDirection: 'column' }}>
-            {status === 'OK' &&
-              data.map(({ place_id, structured_formatting }) => (
-                <Options key={place_id} value={structured_formatting.main_text}>
-                  <Box key={place_id} sx={{ display: 'flex', mt: '1rem' }}>
-                    <LocationOn />
-                    <Stack sx={{ wordWrap: 'break-word' }}>
-                      <Typography variant='body2' color='black.main' fontSize='1rem'>
-                        {structured_formatting.main_text}
-                      </Typography>
-                      <Typography variant='body2' color='primary' fontSize='0.8rem'>
-                        {structured_formatting.secondary_text}
-                      </Typography>
-                    </Stack>
-                  </Box>
-                </Options>
-              ))}
-          </Box>
-        </ComboboxList>
-      </PopOver>
+      <AutoCompleteList suggestions={suggestions} />
     </Combobox>
   );
 };
@@ -107,24 +67,5 @@ const SearchInput = styled(ComboboxInput)(({ theme }) => ({
   '&:focus': {
     borderBottom: `2px solid ${theme.palette.blue050.main}`,
     outline: 'none',
-  },
-}));
-
-const PopOver = styled(ComboboxPopover)(({ theme }) => ({
-  borderRadius: '0 0 10px 10px',
-  background: theme.palette.blue010.main,
-  zIndex: 5000,
-}));
-
-const Options = styled(ComboboxOption)(({ theme }) => ({
-  cursor: 'pointer',
-  margin: 0,
-  padding: '0 0.25rem',
-
-  '&:hover': {
-    background: theme.palette.gray030.main,
-    '&:last-child': {
-      borderRadius: '0 0 10px 10px',
-    },
   },
 }));

--- a/src/components/SearchModal/SearchModal.tsx
+++ b/src/components/SearchModal/SearchModal.tsx
@@ -3,7 +3,7 @@ import { Box, Drawer, Stack, Typography } from '@mui/material';
 import { CenterStyle } from '@/styles/CenterStyle';
 import { theme } from '@/styles/MuiTheme';
 
-import { AutoComplete } from './';
+import { AutoComplete, PlacesAutocomplete } from './';
 
 interface SearchModalProps {
   isOpen: boolean;
@@ -16,7 +16,9 @@ const SearchModal = ({ isOpen, onClose }: SearchModalProps) => {
       <Box sx={WrapperStyle}>
         <Stack flexGrow={1} width='70%'>
           <Box sx={{ ...CenterStyle, my: '2rem' }}>
-            <AutoComplete />
+            <AutoComplete>
+              <PlacesAutocomplete />
+            </AutoComplete>
           </Box>
           <Box component='div' sx={CenterStyle}>
             <Typography component='div' sx={PopularSearchStyle}>

--- a/src/components/SearchModal/index.ts
+++ b/src/components/SearchModal/index.ts
@@ -1,3 +1,4 @@
 export { default as AutoComplete } from './AutoComplete';
+export { default as AutoCompleteList } from './AutoCompleteList';
 export { default as PlacesAutocomplete } from './PlacesAutocomplete';
 export { default as SearchModal } from './SearchModal';

--- a/src/components/SubTravelogue/Location.tsx
+++ b/src/components/SubTravelogue/Location.tsx
@@ -1,7 +1,10 @@
 import { LocationOnOutlined } from '@mui/icons-material';
-import { Box, IconButton, OutlinedInput } from '@mui/material';
+import { Box, IconButton, styled } from '@mui/material';
+import { Combobox, ComboboxInput } from '@reach/combobox';
 import { ControllerRenderProps } from 'react-hook-form';
 
+import { AutoCompleteList } from '@/components/SearchModal';
+import useAutoComplete from '@/hooks/useAutoComplete';
 import { SubTravelogueType } from '@/types/post';
 
 interface LocationProps {
@@ -9,13 +12,32 @@ interface LocationProps {
 }
 
 const Location = ({ field }: LocationProps) => {
+  const { ready, setValue, suggestions, handleSelect } = useAutoComplete();
+
+  const handleRegionSelect = async (region: string) => {
+    field?.onChange(region);
+    handleSelect(region);
+  };
+
   return (
-    <Box sx={locationBoxStyle}>
-      <OutlinedInput {...field} fullWidth placeholder='지역을 입력하세요' type='text' />
-      <IconButton sx={{ position: 'absolute', right: 0, top: '0.5rem' }}>
-        <LocationOnOutlined />
-      </IconButton>
-    </Box>
+    <Combobox onSelect={handleRegionSelect} style={{ width: '70%' }}>
+      <Box sx={locationBoxStyle}>
+        <SearchInput
+          {...field}
+          placeholder='장소를 입력하세요'
+          value={field?.value}
+          onChange={(e) => {
+            field?.onChange(e.target.value);
+            setValue(e.target.value);
+          }}
+          disabled={!ready}
+        />
+        <IconButton sx={{ position: 'absolute', right: '2px', top: '0.5rem' }}>
+          <LocationOnOutlined />
+        </IconButton>
+        <AutoCompleteList suggestions={suggestions} />
+      </Box>
+    </Combobox>
   );
 };
 
@@ -27,3 +49,17 @@ const locationBoxStyle = {
   position: 'relative',
   width: '100%',
 };
+
+const SearchInput = styled(ComboboxInput)(() => ({
+  width: '100%',
+  height: '1.4375em',
+  padding: '16.5px 14px',
+  border: '1px solid rgba(0, 0, 0, 0.23)',
+  borderRadius: '4px',
+  font: 'normal 400 1rem/1.4375em KOHINanumOTFL, sans-serif',
+  color: 'rgba(0, 0, 0, 0.87)',
+  '&:focus': {
+    border: `2px solid #1976d2`,
+    outline: 'none',
+  },
+}));

--- a/src/components/SubTravelogue/VisitedRegion.tsx
+++ b/src/components/SubTravelogue/VisitedRegion.tsx
@@ -3,6 +3,7 @@ import { Button, IconButton, Stack } from '@mui/material';
 import { Control, Controller, useFieldArray } from 'react-hook-form';
 
 import { SubTitle } from '@/components/common';
+import { AutoComplete } from '@/components/SearchModal';
 import { SubTravelogueType } from '@/types/post';
 
 import { Location } from '.';
@@ -28,7 +29,11 @@ const VisitedRegion = ({ control }: VisitedRegionProps) => {
       {fields.map((item, index) => (
         <Stack key={item.id} direction='row' spacing={2} component='li'>
           <Controller
-            render={({ field }) => <Location field={field} />}
+            render={({ field }) => (
+              <AutoComplete>
+                <Location field={field} />
+              </AutoComplete>
+            )}
             name={`addresses.${index}.region`}
             control={control}
             rules={{ required: true }}

--- a/src/hooks/useAutoComplete.ts
+++ b/src/hooks/useAutoComplete.ts
@@ -1,0 +1,21 @@
+import usePlacesAutocomplete from 'use-places-autocomplete';
+
+const useAutoComplete = () => {
+  const { ready, value, setValue, suggestions, clearSuggestions } =
+    usePlacesAutocomplete();
+
+  const handleSelect = async (address: string) => {
+    setValue(address, false);
+    clearSuggestions();
+  };
+
+  return {
+    ready,
+    value,
+    setValue,
+    suggestions,
+    handleSelect,
+  };
+};
+
+export default useAutoComplete;


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #109 

## 📝 작업 내용

- [x] 검색 모달 창의 자동 완성 관련 로직을 커스텀 훅으로 분리하였습니다.
- [x] 서브 트래블로그의 지역 인풋에 자동 완성 로직을 추가하였습니다.

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/63948884/224507650-232a8048-e1b9-44cc-84a0-802f44230517.png)
