### PR TITLE
[feat] 프로필 관리 페이지 API 연결

### DIFF
--- a/src/api/hooks/profile.ts
+++ b/src/api/hooks/profile.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getUserInformation } from '../profile';
+
+export const useUserInformation = () => {
+  return useQuery({
+    queryKey: ['USER_INFORMATION'],
+    queryFn: () => getUserInformation(),
+  });
+};

--- a/src/api/hooks/profile.ts
+++ b/src/api/hooks/profile.ts
@@ -1,10 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { UserInformationType } from '@/types/profile';
 
 import { getUserInformation } from '../profile';
 
 export const useUserInformation = () => {
-  return useQuery({
+  const [userInformation, setUserInformation] = useState<UserInformationType>({
+    email: '',
+    nickname: '',
+    profileImageUrl: '',
+    birthYear: '',
+  });
+
+  const { isLoading } = useQuery({
     queryKey: ['USER_INFORMATION'],
     queryFn: () => getUserInformation(),
+    onSuccess: (data) => {
+      setUserInformation(data);
+    },
   });
+
+  return { userInformation, isLoading } as const;
 };

--- a/src/api/hooks/profile.ts
+++ b/src/api/hooks/profile.ts
@@ -1,9 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { useState } from 'react';
 
-import { UserInformationType } from '@/types/profile';
-
-import { getUserInformation } from '../profile';
+import { getUserInformation, patchUserInformation } from '@/api/profile';
+import { UserInformationPatchType, UserInformationType } from '@/types/profile';
 
 export const useUserInformation = () => {
   const [userInformation, setUserInformation] = useState<UserInformationType>({
@@ -21,5 +21,25 @@ export const useUserInformation = () => {
     },
   });
 
-  return { userInformation, isLoading } as const;
+  const { mutate } = useMutation({
+    mutationFn: async (data: UserInformationPatchType) =>
+      await patchUserInformation(data),
+    onSuccess: (data) => {
+      setUserInformation(data);
+    },
+    onError: ({ message }: AxiosError) => {
+      console.error(message);
+    },
+  });
+
+  // Patch Method Test
+  const handleChangeUserInformation = () => {
+    mutate({
+      nickname: 'moom',
+      profileImageUrl:
+        'https://travel-zip-bucket.s3.ap-northeast-2.amazonaws.com/upload/4ad6520e-7498-4d19-b022-67701a6599e1EfW549HUMAEGALk.jpeg',
+    });
+  };
+
+  return { userInformation, isLoading, handleChangeUserInformation } as const;
 };

--- a/src/api/profile/index.ts
+++ b/src/api/profile/index.ts
@@ -1,0 +1,8 @@
+import http from '@/api/core/axiosInstance';
+import { UserInformationType } from '@/types/profile';
+
+export const getUserInformation = async (): Promise<UserInformationType> => {
+  const response = await http.get('api/members/my/info');
+
+  return response.data;
+};

--- a/src/api/profile/index.ts
+++ b/src/api/profile/index.ts
@@ -1,8 +1,16 @@
 import http from '@/api/core/axiosInstance';
-import { UserInformationType } from '@/types/profile';
+import { UserInformationPatchType, UserInformationType } from '@/types/profile';
 
 export const getUserInformation = async (): Promise<UserInformationType> => {
   const response = await http.get('api/members/my/info');
+
+  return response.data;
+};
+
+export const patchUserInformation = async (
+  data: UserInformationPatchType,
+): Promise<UserInformationType> => {
+  const response = await http.patch('api/members/my/settings', data);
 
   return response.data;
 };

--- a/src/components/Profile/Management.tsx
+++ b/src/components/Profile/Management.tsx
@@ -6,9 +6,15 @@ interface ManagementProps {
   nickname: string;
   profileImage: string;
   isLoading: boolean;
+  handleChangeUserInformation: () => void;
 }
 
-const Management = ({ nickname, profileImage, isLoading }: ManagementProps) => {
+const Management = ({
+  nickname,
+  profileImage,
+  isLoading,
+  handleChangeUserInformation,
+}: ManagementProps) => {
   return (
     <Stack
       spacing={2}
@@ -23,7 +29,11 @@ const Management = ({ nickname, profileImage, isLoading }: ManagementProps) => {
         sx={{ font: '1.25rem bold', color: 'dark.main' }}>
         {nickname}
       </Typography>
-      <CommonButton content='프로필 수정' customStyle={{ height: 40 }} />
+      <CommonButton
+        content='프로필 수정'
+        customStyle={{ height: 40 }}
+        handleClick={handleChangeUserInformation}
+      />
     </Stack>
   );
 };

--- a/src/components/Profile/Management.tsx
+++ b/src/components/Profile/Management.tsx
@@ -5,9 +5,10 @@ import { CommonButton, ProfileAvatar } from '@/components/common';
 interface ManagementProps {
   nickname: string;
   profileImage: string;
+  isLoading: boolean;
 }
 
-const Management = ({ nickname, profileImage }: ManagementProps) => {
+const Management = ({ nickname, profileImage, isLoading }: ManagementProps) => {
   return (
     <Stack
       spacing={2}
@@ -15,7 +16,7 @@ const Management = ({ nickname, profileImage }: ManagementProps) => {
       alignItems='center'
       justifyContent='center'
       bgcolor='gray005.main'>
-      <ProfileAvatar url={profileImage} size={100} iconSize={5} />
+      <ProfileAvatar url={profileImage} size={100} iconSize={5} isLoading={isLoading} />
       <Typography
         variant='h2'
         component='h2'

--- a/src/components/common/ProfileAvatar.tsx
+++ b/src/components/common/ProfileAvatar.tsx
@@ -1,13 +1,18 @@
 import { Person as PersonIcon } from '@mui/icons-material';
-import { Avatar } from '@mui/material';
+import { Avatar, Skeleton } from '@mui/material';
 
 interface ProfileAvatarProps {
   url: string;
   size: number;
   iconSize: number;
+  isLoading: boolean;
 }
 
-const ProfileAvatar = ({ url, size, iconSize }: ProfileAvatarProps) => {
+const ProfileAvatar = ({ url, size, iconSize, isLoading }: ProfileAvatarProps) => {
+  if (isLoading) {
+    return <Skeleton variant='circular' width={size} height={size} />;
+  }
+
   return (
     <Avatar
       src={url !== 'default' ? url : undefined}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,20 +1,21 @@
 import { Stack } from '@mui/material';
 
+import { useUserInformation } from '@/api/hooks/profile';
 import { ContentLink, Management } from '@/components/Profile';
 
-const DUMMY_DATA = {
-  email: 'dodnjs1241@naver.com',
-  nickname: '예오닝',
-  birthYear: '1996',
-  profileImageUrl: 'default',
-};
-
 const Profile = () => {
+  const { userInformation, isLoading } = useUserInformation();
+
+  if (!userInformation) {
+    return null;
+  }
+
   return (
     <Stack>
       <Management
-        profileImage={DUMMY_DATA.profileImageUrl}
-        nickname={DUMMY_DATA.nickname}
+        profileImage={userInformation.profileImageUrl}
+        nickname={userInformation.nickname}
+        isLoading={isLoading}
       />
       <Stack alignItems='center'>
         <ContentLink contentName='내가 작성한 게시물' route='/' iconName='edit' />

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -4,7 +4,8 @@ import { useUserInformation } from '@/api/hooks/profile';
 import { ContentLink, Management } from '@/components/Profile';
 
 const Profile = () => {
-  const { userInformation, isLoading } = useUserInformation();
+  const { userInformation, isLoading, handleChangeUserInformation } =
+    useUserInformation();
 
   if (!userInformation) {
     return null;
@@ -16,6 +17,7 @@ const Profile = () => {
         profileImage={userInformation.profileImageUrl}
         nickname={userInformation.nickname}
         isLoading={isLoading}
+        handleChangeUserInformation={handleChangeUserInformation}
       />
       <Stack alignItems='center'>
         <ContentLink contentName='내가 작성한 게시물' route='/' iconName='edit' />

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,6 +1,9 @@
-export interface UserInformationType {
-  email: string;
+export interface UserInformationPatchType {
   nickname: string;
-  birthYear: string;
   profileImageUrl: string;
 }
+
+export type UserInformationType = {
+  email: string;
+  birthYear: string;
+} & UserInformationPatchType;

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,6 @@
+export interface UserInformationType {
+  email: string;
+  nickname: string;
+  birthYear: string;
+  profileImageUrl: string;
+}


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #108 

## 📝 작업 내용

- 유저 정보 조회 API 연결 
- 유저 정보 조회 데이터 React 상태 관리
- 유저 프로필 수정 API 연결
- 유저 프로필 수정 이벤트 함수 구현 & 유정 정보 조회 데이터 동기화

## 📍 PR Point

- `@/types/profile.ts` UserInformationPatchType 이름이 명확하다고 생각하나요? 다른 명확한 이름이 있다면 추천해주세요.
- 현재 `auth`, `user`, `profile` 폴더명 또는 파일명이 명확하게 구분되어 있지 않습니다. 리팩터링 기간에 인증 관련(로그인, 회원가입) 로직은 auth로 통일하고, 유저 정보 관려(유저 정보) 로직은 user로 통일해야 합니다. 



