### PR TITLE
[design] Navigation Bar 최하단으로 위치 재구성

### DIFF
--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -3,6 +3,7 @@ import {
   ConnectingAirports as ConnectingAirportsIcon,
   Person as PersonIcon,
 } from '@mui/icons-material';
+import { styled } from '@mui/material';
 import { BottomNavigation, BottomNavigationAction } from '@mui/material';
 import { useState } from 'react';
 
@@ -10,15 +11,7 @@ const GNB = () => {
   const [value, setValue] = useState<'home' | 'add' | 'profile'>('home');
 
   return (
-    <BottomNavigation
-      sx={{
-        position: 'sticky',
-        bottom: 0,
-        bgcolor: 'blue010.main',
-        zIndex: '1201',
-      }}
-      value={value}
-      onChange={(_, newValue) => setValue(newValue)}>
+    <StyledBottomNavigation value={value} onChange={(_, newValue) => setValue(newValue)}>
       <BottomNavigationAction
         label='Home'
         value='home'
@@ -26,8 +19,22 @@ const GNB = () => {
       />
       <BottomNavigationAction label='Add' value='add' icon={<AddCircleIcon />} />
       <BottomNavigationAction label='Profile' value='profile' icon={<PersonIcon />} />
-    </BottomNavigation>
+    </StyledBottomNavigation>
   );
 };
 
 export default GNB;
+
+const StyledBottomNavigation = styled(BottomNavigation)(({ theme }) => ({
+  [theme.breakpoints.down('mobile')]: {
+    width: 390,
+  },
+  [theme.breakpoints.up('mobile')]: {
+    width: 414,
+  },
+  position: 'fixed',
+  bottom: 0,
+  backgroundColor: theme.palette.blue010.main,
+  minHeight: 65,
+  boxShadow: '0px 2px 6px rgba(0, 0, 0, 0.2)',
+}));

--- a/src/styles/MuiTheme.ts
+++ b/src/styles/MuiTheme.ts
@@ -15,11 +15,11 @@ declare module '@mui/material' {
 
 declare module '@mui/material/styles' {
   interface BreakpointOverrides {
-    xs: false; // removes the `xs` breakpoint
+    xs: true; // removes the `xs` breakpoint
     sm: true;
-    md: false;
-    lg: false;
-    xl: false;
+    md: true;
+    lg: true;
+    xl: true;
     mobile: true; // adds the `mobile` breakpoint
   }
 }
@@ -51,7 +51,12 @@ export const theme = createTheme({
   breakpoints: {
     values: {
       mobile: 390,
+
+      xs: 0,
       sm: 600,
+      md: 900,
+      lg: 1200,
+      xl: 1536,
     },
   },
 });

--- a/src/styles/MuiTheme.ts
+++ b/src/styles/MuiTheme.ts
@@ -13,6 +13,17 @@ declare module '@mui/material' {
   interface InputBasePropsColorOverrides extends PaletteOverrides<typeof palette, true> {}
 }
 
+declare module '@mui/material/styles' {
+  interface BreakpointOverrides {
+    xs: false; // removes the `xs` breakpoint
+    sm: false;
+    md: false;
+    lg: false;
+    xl: false;
+    mobile: true; // adds the `mobile` breakpoint
+  }
+}
+
 type PaletteOverrides<T extends object, X> = { [key in keyof T]: X };
 
 const palette = {
@@ -36,5 +47,10 @@ export const theme = createTheme({
   palette,
   typography: {
     fontFamily: 'KOHINanumOTFL',
+  },
+  breakpoints: {
+    values: {
+      mobile: 390,
+    },
   },
 });

--- a/src/styles/MuiTheme.ts
+++ b/src/styles/MuiTheme.ts
@@ -16,7 +16,7 @@ declare module '@mui/material' {
 declare module '@mui/material/styles' {
   interface BreakpointOverrides {
     xs: false; // removes the `xs` breakpoint
-    sm: false;
+    sm: true;
     md: false;
     lg: false;
     xl: false;
@@ -51,6 +51,7 @@ export const theme = createTheme({
   breakpoints: {
     values: {
       mobile: 390,
+      sm: 600,
     },
   },
 });


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #120 

## 📝 작업 내용
**design**
- 각 화면이 렌더링 되기전에 Navigation Bar 앱 최하단에 고정되어 있지 않아서 Header 영역 바로 아래에 레이아웃되는 문제 해결하기
- 각 화면(Main 영역)마다 Navigation Bar 위치가 최하단에 위치하게 레이아웃 재구성

**fix**
- `@/components/CreatePost/ComplexButton.tsx` 컴포넌트에서 Mui Breakpoints 기본 옵션 (xs, sm, md, lg, xl)이 의존하고 있어서 다시 추가

## 📍 PR Point
- [Mui Breakpoints](https://mui.com/material-ui/customization/breakpoints/#css-media-queries)

## 📷 스크린샷
- 각 화면(Main 영역)마다 Navigation Bar 위치가 최하단에 위치하게 레이아웃 재구성
<img src="https://user-images.githubusercontent.com/57402711/224546663-2d7cc83c-ebcd-4153-a090-9f06b45a6a9f.jpg" width="30%" /><img src="https://user-images.githubusercontent.com/57402711/224546671-2235b137-2880-40b8-9c72-96f82a2d1c93.jpg" width="29.9%" />

- 각 화면이 렌더링 되기전에 Navigation Bar 앱 최하단에 고정되어 있지 않아서 Header 영역 바로 아래에 레이아웃되는 문제

https://user-images.githubusercontent.com/57402711/224546867-c32a1aac-e4d1-4d61-8029-21c877bd83bf.mov


https://user-images.githubusercontent.com/57402711/224548814-8a1ce100-c6de-4c52-9a99-d7e3eb603389.mov


