### PR TITLE
[feat] Navigation Bar 라우터 연결

### DIFF
--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -9,12 +9,20 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 
 import { PATH_ROUTER } from '@/constants/path';
+import { PathRouterType } from '@/types/common';
+import { getInitialPathName } from '@/utils/helper';
 
 const GNB = () => {
   const router = useRouter();
+  const [value, setValue] = useState<PathRouterType>(
+    getInitialPathName(router.pathname as PathRouterType),
+  );
 
-  const [value, setValue] = useState<keyof typeof PATH_ROUTER>('home');
-  const onChangeNavigationRoute = (_: unknown, newValue: keyof typeof PATH_ROUTER) => {
+  const onChangeNavigationRoute = (_: unknown, newValue: PathRouterType) => {
+    if (value === newValue) {
+      return;
+    }
+
     setValue(newValue);
     router.push(PATH_ROUTER[newValue]);
   };

--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -5,13 +5,22 @@ import {
 } from '@mui/icons-material';
 import { styled } from '@mui/material';
 import { BottomNavigation, BottomNavigationAction } from '@mui/material';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 
+import { PATH_ROUTER } from '@/constants/path';
+
 const GNB = () => {
-  const [value, setValue] = useState<'home' | 'add' | 'profile'>('home');
+  const router = useRouter();
+
+  const [value, setValue] = useState<keyof typeof PATH_ROUTER>('home');
+  const onChangeNavigationRoute = (_: unknown, newValue: keyof typeof PATH_ROUTER) => {
+    setValue(newValue);
+    router.push(PATH_ROUTER[newValue]);
+  };
 
   return (
-    <StyledBottomNavigation value={value} onChange={(_, newValue) => setValue(newValue)}>
+    <StyledBottomNavigation value={value} onChange={onChangeNavigationRoute}>
       <BottomNavigationAction
         label='Home'
         value='home'

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,0 +1,5 @@
+export const PATH_ROUTER = {
+  home: '/',
+  add: '/post/first',
+  profile: '/profile',
+};

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,5 +1,7 @@
 import { Control, FieldPath, FieldValues, RegisterOptions } from 'react-hook-form';
 
+import { PATH_ROUTER } from '@/constants/path';
+
 export interface FormControlType<T extends FieldValues> {
   control: Control<T>;
   name: FieldPath<T>;
@@ -8,3 +10,5 @@ export interface FormControlType<T extends FieldValues> {
     'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'
   >;
 }
+
+export type PathRouterType = keyof typeof PATH_ROUTER;

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,5 +1,8 @@
 import { Dayjs } from 'dayjs';
 
+import { PATH_ROUTER } from '@/constants/path';
+import { PathRouterType } from '@/types/common';
+
 export const getDateInfo = (date: Dayjs) => {
   return date.format('YYYY-MM-DD');
 };
@@ -7,3 +10,10 @@ export const getDateInfo = (date: Dayjs) => {
 export const createPeriodArray = (days: number) => {
   return Array.from({ length: days }, (_, i) => `${i + 1}일차`);
 };
+
+export const getInitialPathName = (pathname: PathRouterType) =>
+  Object.entries(PATH_ROUTER)
+    .filter((pathInformationArray) => {
+      return pathname === pathInformationArray[1];
+    })
+    .flat()[0] as PathRouterType;


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #123 

## 📝 작업 내용

- Navigation Bar에 의존하고 있는 페이지 `end-point(url)` 상수 객체로 모듈화
- 상수 객체 모듈에 의존하는 route 연결
- 동일한 `end-point(url)`를 연속해서 클릭 방지 기능 구현
- 새로고침을 해도 `end-point(url)`와 네비게이션 value 동기화 기능 구현

## 📍 PR Point
- `@/utils/helper.ts` `getInitialPathName` 함수가 가독성이 좋지 못한 로직이라고 생각합니다. 이해하기 쉬운 로직으로 바꾸려면 어떻게 하면 좋을까요? -> `Array.prototype.reduce` 함수를 사용하고 싶었지만 구현하지 못했습니다. 팀원들 의견이 궁금합니다.

## 📷 스크린샷

https://user-images.githubusercontent.com/57402711/224555339-a6e0993c-4cb0-4acd-a50e-90d4858311e6.mov



