### PR TITLE
[design] global-font 변경

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -88,7 +88,7 @@ const Search = styled('div')(({ theme }) => ({
   },
   marginLeft: 0,
   width: '100%',
-  [theme.breakpoints.up('sm')]: {
+  [theme.breakpoints.up('xs')]: {
     width: 'auto',
     marginLeft: theme.spacing(0.5),
   },
@@ -111,7 +111,7 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
     padding: theme.spacing(1, 1, 1, 0),
     paddingLeft: `calc(1em + ${theme.spacing(4)})`,
     transition: theme.transitions.create('width'),
-    [theme.breakpoints.up('sm')]: {
+    [theme.breakpoints.up('xs')]: {
       width: '0ch',
       '&:focus': {
         width: '15ch',
@@ -133,8 +133,8 @@ const BoxStyle = {
 } as const;
 
 const LogoStyle = {
-  display: { xs: 'none', sm: 'block' },
-  fontSize: '1rem',
-  fontFamily: 'KOHIBaeum',
+  fontSize: '1.2rem',
+  fontFamily: 'Noto Sans KR',
+  fontWeight: '900',
   cursor: 'pointer',
 } as const;

--- a/src/components/Login/Local.tsx
+++ b/src/components/Login/Local.tsx
@@ -54,6 +54,7 @@ const Local = () => {
         />
         <CommonInput
           id='password'
+          type='password'
           label='비밀번호'
           variant='outlined'
           control={control}

--- a/src/components/Register/Register.tsx
+++ b/src/components/Register/Register.tsx
@@ -100,7 +100,7 @@ const Register = ({ control, setValidNickname, setError, trigger }: RegisterProp
         placeholder='비밀번호 최소 8자 영문/숫자/특수문자'
         label='비밀번호'
         variant='outlined'
-        // type='password'
+        type='password'
         helperText={passwordState.error && passwordState.error.message}
       />
       <TextField
@@ -108,7 +108,7 @@ const Register = ({ control, setValidNickname, setError, trigger }: RegisterProp
         id='outlined-basic'
         label='비밀번호 확인'
         variant='outlined'
-        // type='password'
+        type='password'
         helperText={passwordConfirmState.error && passwordConfirmState.error.message}
       />
       <FormControl fullWidth>

--- a/src/components/SubTravelogue/Location.tsx
+++ b/src/components/SubTravelogue/Location.tsx
@@ -56,7 +56,7 @@ const SearchInput = styled(ComboboxInput)(() => ({
   padding: '16.5px 14px',
   border: '1px solid rgba(0, 0, 0, 0.23)',
   borderRadius: '4px',
-  font: 'normal 400 1rem/1.4375em KOHINanumOTFL, sans-serif',
+  font: 'normal 400 1rem/1.4375em Noto Sans KR, sans-serif',
   color: 'rgba(0, 0, 0, 0.87)',
   '&:focus': {
     border: `2px solid #1976d2`,

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -13,7 +13,6 @@ const style = css`
     margin: 0;
     font-family: 'Noto Sans KR', sans-serif;
     line-height: 1;
-    word-spacing: -5px;
   }
 
   div,

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -7,25 +7,11 @@ const GlobalStyle = () => {
 export default GlobalStyle;
 
 const style = css`
-  @font-face {
-    font-weight: normal;
-    font-family: 'KOHINanumOTFL';
-    font-style: normal;
-    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2201-2@1.0/KOHINanumOTFL.woff')
-      format('woff');
-  }
-
-  @font-face {
-    font-weight: normal;
-    font-family: 'KOHIBaeumOTF';
-    font-style: normal;
-    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2201-2@1.0/KOHIBaeumOTF.woff')
-      format('woff');
-  }
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap');
 
   body {
     margin: 0;
-    font-family: 'KOHINanumOTFL', serif;
+    font-family: 'Noto Sans KR', sans-serif;
     line-height: 1;
     word-spacing: -5px;
   }

--- a/src/styles/MuiTheme.ts
+++ b/src/styles/MuiTheme.ts
@@ -51,7 +51,6 @@ export const theme = createTheme({
   breakpoints: {
     values: {
       mobile: 390,
-
       xs: 0,
       sm: 600,
       md: 900,

--- a/src/styles/MuiTheme.ts
+++ b/src/styles/MuiTheme.ts
@@ -46,7 +46,7 @@ const palette = {
 export const theme = createTheme({
   palette,
   typography: {
-    fontFamily: 'KOHINanumOTFL',
+    fontFamily: 'Noto Sans KR',
   },
   breakpoints: {
     values: {


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #126

## 📝 작업 내용

- 폰트를 Noto Sans Korean로 변경했습니다.
- 폰트 변경에 따라 비밀번호 입력 타입을 password로 변경했습니다.
- 헤더의 크기가 sm 보다 작아지면 이상하게 보이는 현상을 변경했습니다.
- body와 mui-typography의 font-family를 Noto Sans KR로 변경했습니다.

## 📍 PR Point

- 사용가능한 font-weight: 100, 300, 400, 500, 700, 900 입니다(최종에서 사용하지 않는 font-weight는 삭제 예정 )

## 📷 스크린샷
