### PR TITLE
[feat] 서브 트래블로그 수정 기능 구현 

### DIFF
--- a/src/api/hooks/post.ts
+++ b/src/api/hooks/post.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 import {
+  getSubTravelogueForEdit,
   getTravelogueForEdit,
   patchSubTravelogue,
   patchTravelogue,
@@ -51,5 +52,15 @@ export const useGetTravelogueForEdit = (travelogueId: string) => {
     queryKey: ['TRAVELOGUE', travelogueId],
     queryFn: () => getTravelogueForEdit(travelogueId),
     enabled: false,
+  });
+};
+
+export const useGetSubTravelogueForEdit = (
+  travelogueId: string,
+  subTravelogueId: string,
+) => {
+  return useQuery({
+    queryKey: ['SUB_TRAVELOGUE', travelogueId, subTravelogueId],
+    queryFn: () => getSubTravelogueForEdit(travelogueId, subTravelogueId),
   });
 };

--- a/src/api/post/index.ts
+++ b/src/api/post/index.ts
@@ -65,13 +65,10 @@ export const getTravelogueForEdit = async (
   return await http.get(`api/members/my/travelogues/${travelogueId}`);
 };
 
-export const getSubTravelogueForEdit = async ({
-  travelogueId,
-  subTravelogueId,
-}: {
-  travelogueId: string;
-  subTravelogueId: string;
-}) => {
+export const getSubTravelogueForEdit = async (
+  travelogueId: string,
+  subTravelogueId: string,
+) => {
   return await http.get(
     `api/members/my/travelogues/${travelogueId}/subTravelogues/${subTravelogueId}`,
   );

--- a/src/components/Stepper/VerticalStepper.tsx
+++ b/src/components/Stepper/VerticalStepper.tsx
@@ -37,6 +37,7 @@ const VerticalStepper = ({ travelogueId, subTravelogueStep }: VerticalStepperPro
               <SubTravelogue
                 travelogueId={travelogueId}
                 index={index}
+                isEditPage={false}
                 handleComplete={handleComplete}
               />
             </StepContent>

--- a/src/components/TravelogueDetail/TravelogueContent.tsx
+++ b/src/components/TravelogueDetail/TravelogueContent.tsx
@@ -1,31 +1,48 @@
 import { ConnectingAirports as ConnectingAirportsIcon } from '@mui/icons-material';
-import { Box, Card, CardContent, Divider, Stack, Typography } from '@mui/material';
+import { Button, Card, CardContent, Divider, Stack, Typography } from '@mui/material';
 import Parser from 'html-react-parser';
+import { useRouter } from 'next/router';
 
 import { Title } from '@/components/common';
 import { VisitedRegionList } from '@/components/TravelogueDetail';
-import { SubTravelogueType } from '@/types/post';
+import { SubTravelogueDetailType } from '@/types/post';
 
-interface PostContentsProps {
-  subTravelogue: SubTravelogueType;
+interface TravelogueContentProps {
+  travelogueId: number;
+  subTravelogue: SubTravelogueDetailType;
 }
 
-const TravelogueContent = ({ subTravelogue }: PostContentsProps) => {
-  const { day, title, content, addresses } = subTravelogue;
+const TravelogueContent = ({ travelogueId, subTravelogue }: TravelogueContentProps) => {
+  const { subTravelogueId: id, day, title, content, addresses } = subTravelogue;
+  const router = useRouter();
+
+  const handleEditClick = () => {
+    router.push({
+      pathname: '/post/[id]',
+      query: { id, travelogueId, day, edit: true },
+    });
+  };
 
   return (
     <Card variant='outlined'>
       <CardContent>
         <Stack>
-          <Stack direction='row' spacing={0.5} alignItems={'center'}>
-            <ConnectingAirportsIcon color={'blue050'} />
-            <Typography variant='subtitle1' color='dark.main'>{`${day}일차`}</Typography>
+          <Stack direction='row' alignItems={'center'} justifyContent={'space-between'}>
+            <Stack direction='row' spacing={0.7}>
+              <ConnectingAirportsIcon color={'blue050'} />
+              <Typography
+                variant='subtitle1'
+                color='dark.main'>{`${day}일차`}</Typography>
+            </Stack>
+            <Button variant='text' sx={{ minWidth: 0 }} onClick={handleEditClick}>
+              수정
+            </Button>
           </Stack>
           <Title bold='bold' sx={{ mt: 0.5 }}>
             {title}
           </Title>
           <Divider sx={{ my: 2 }} />
-          <Box sx={{ lineHeight: 1.5 }}>{Parser(content)}</Box>
+          <Stack sx={{ lineHeight: 1.5 }}>{Parser(content)}</Stack>
           <VisitedRegionList addresses={addresses} />
         </Stack>
       </CardContent>

--- a/src/components/TravelogueDetail/TravelogueDetail.tsx
+++ b/src/components/TravelogueDetail/TravelogueDetail.tsx
@@ -10,13 +10,17 @@ interface TravelogueDetailProps {
 
 const TravelogueDetail = ({ travelogueDetail }: TravelogueDetailProps) => {
   const authority = 'writer'; // viewer
-  const { subTravelogues,  } = travelogueDetail;
+  const { id, subTravelogues } = travelogueDetail;
 
   return (
     <Stack spacing={3}>
       <TravelogueHeader authority={authority} travelogueDetail={travelogueDetail} />
       {subTravelogues.map((subTravelogue) => (
-        <TravelogueContent key={subTravelogue.day} subTravelogue={subTravelogue} />
+        <TravelogueContent
+          key={subTravelogue.subTravelogueId}
+          travelogueId={id}
+          subTravelogue={subTravelogue}
+        />
       ))}
     </Stack>
   );

--- a/src/components/TravelogueDetail/TravelogueHeader.tsx
+++ b/src/components/TravelogueDetail/TravelogueHeader.tsx
@@ -42,7 +42,14 @@ const TravelogueHeader = ({ authority, travelogueDetail }: PostInfoProps) => {
         )}
       </Stack>
       <Box sx={{ position: 'relative', width: '100%', height: '220px' }}>
-        <Image src={thumbnail} fill alt='thumbnail' style={{ borderRadius: '10px' }} />
+        <Image
+          src={thumbnail}
+          fill
+          alt='thumbnail'
+          style={{ borderRadius: '10px' }}
+          sizes='300px'
+          priority
+        />
       </Box>
       <TravelInfo travelogueDetail={travelogueDetail} />
     </Stack>

--- a/src/components/TravelogueDetail/TravelogueInfo.tsx
+++ b/src/components/TravelogueDetail/TravelogueInfo.tsx
@@ -11,12 +11,11 @@ interface PostProfileProps {
 const TravelogueInfo = ({ travelogueDetail }: PostProfileProps) => {
   const { nickname, viewCount, profileImageUrl } = travelogueDetail;
 
-  console.log(profileImageUrl);
   return (
     <Stack direction='row' spacing={2} my={1}>
       <Stack direction='row' spacing={0.5} alignItems={'center'} key={nickname}>
         <Avatar
-          src={profileImageUrl}
+          src={profileImageUrl !== 'default' ? profileImageUrl : undefined}
           sx={{ ...InfoStyle, backgroundColor: 'gray020.main' }}
         />
         <SubTitle fontSize='0.9rem' color='gray030.main'>

--- a/src/hooks/useHandleTraveloguePublish.ts
+++ b/src/hooks/useHandleTraveloguePublish.ts
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/router';
+
+import { usePatchTraveloguePublish } from '@/api/hooks/post';
+
+const useHandleTraveloguePublish = (travelogueId: string) => {
+  const router = useRouter();
+  const { mutate } = usePatchTraveloguePublish();
+
+  const handleTraveloguePublish = () => {
+    mutate(
+      { travelogueId },
+      {
+        onSuccess: ({ data }) => {
+          router.push({
+            pathname: '/detail',
+            query: { travelogueId: data.travelogueId },
+          });
+        },
+      },
+    );
+  };
+
+  return { handleTraveloguePublish };
+};
+
+export default useHandleTraveloguePublish;

--- a/src/pages/post/[id].tsx
+++ b/src/pages/post/[id].tsx
@@ -2,17 +2,20 @@ import { Box, Button } from '@mui/material';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
-import { usePatchTraveloguePublish } from '@/api/hooks/post';
 import { VerticalStepper } from '@/components/Stepper';
 import { TravelogueInfoType } from '@/components/Stepper/VerticalStepper';
+import { SubTravelogue } from '@/components/SubTravelogue';
+import useHandleTraveloguePublish from '@/hooks/useHandleTraveloguePublish';
 import { getItem } from '@/utils/storage';
 
 const SubTraveloguePage = () => {
   const router = useRouter();
   const [travelogueId, setTravelogueId] = useState('');
   const [subTravelogueStep, setSubTravelogueStep] = useState<string[]>([]);
-  const { mutate } = usePatchTraveloguePublish();
+  const [isEditPage, setIsEditPage] = useState(false);
+  const [day, setDay] = useState('');
   const isClient = typeof window !== 'undefined';
+  const { handleTraveloguePublish } = useHandleTraveloguePublish(travelogueId);
 
   useEffect(() => {
     if (isClient) {
@@ -22,36 +25,41 @@ const SubTraveloguePage = () => {
     }
   }, [isClient]);
 
-  const handleTraveloguePublish = () => {
-    mutate(
-      { travelogueId },
-      {
-        onSuccess: ({ data }) => {
-          router.push({
-            pathname: '/detail',
-            query: { travelogueId: data.travelogueId },
-          });
-        },
-      },
-    );
-  };
+  useEffect(() => {
+    const { travelogueId, day, edit } = router.query;
+    if (travelogueId && day && edit) {
+      setIsEditPage(Boolean(edit as string));
+      setTravelogueId(travelogueId as string);
+      setDay(day as string);
+    }
+  }, [router.isReady, router.query]);
 
   return (
     <Box sx={layout}>
-      <VerticalStepper
-        travelogueId={travelogueId}
-        subTravelogueStep={subTravelogueStep}
-      />
-      <Box sx={{ borderTop: '1px solid #bdbdbd', mt: '20px' }}>
-        <Button
-          type='button'
-          variant='contained'
-          fullWidth
-          sx={{ m: '20px 0' }}
-          onClick={handleTraveloguePublish}>
-          발행
-        </Button>
-      </Box>
+      {isEditPage ? (
+        <SubTravelogue
+          travelogueId={travelogueId}
+          index={parseInt(day)}
+          isEditPage={isEditPage}
+        />
+      ) : (
+        <VerticalStepper
+          travelogueId={travelogueId}
+          subTravelogueStep={subTravelogueStep}
+        />
+      )}
+      {!isEditPage && (
+        <Box sx={{ borderTop: '1px solid #bdbdbd', mt: '20px' }}>
+          <Button
+            type='button'
+            variant='contained'
+            fullWidth
+            sx={{ m: '20px 0' }}
+            onClick={handleTraveloguePublish}>
+            발행
+          </Button>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -48,4 +48,8 @@ export interface SubTravelogueType {
   travelPhotoCreateReqs: { url: string }[];
 }
 
+export interface SubTravelogueDetailType extends SubTravelogueType {
+  subTravelogueId: number;
+}
+
 export type StepType = 'next' | 'back';

--- a/src/types/travelogue.ts
+++ b/src/types/travelogue.ts
@@ -1,4 +1,4 @@
-import { SubTravelogueType } from '@/types/post';
+import { SubTravelogueDetailType } from '@/types/post';
 
 export interface TravelogueFeedType {
   travelogueId: number;
@@ -34,7 +34,7 @@ export interface TravelogueDetailType {
   nights: number;
   days: number;
   totalCost: number;
-  subTravelogues: SubTravelogueType[];
+  subTravelogues: SubTravelogueDetailType[];
   transportations: string[];
   countLikes: number;
   isLiked: boolean;


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #122

## 📝 작업 내용
- [x] 서브 트래블로그 수정 구현

## 📍 PR Point

- 쿼리 파라미터를 그대로 노출시키고 있습니다. 
- 서브 트래블로그 작성시에는 `router.push`의 `as`옵션을 이용하여 URL에 쿼리가 그대로 노출되는 것을 막고 세션 스토리지에 필요한 값들을 저장하여 새로고침이 되어도 값이 날아가지 않게 하였습니다. 
-  쿼리에 담긴 값을 감추는 좋은 방법이 없을까요?
- 사용자가 쿼리 파라미터를 조작하여 다른 사용자의 게시글 수정 페이지로 이동하면 권한이 없다는 문구를 띄워줄 예정입니다. (나중)
  - 현재는 수정 폼이 뜨고 있으나 데이터가 제대로 불러와지지 않고, 수정 버튼을 눌러도 제출이 안됩니다.

## 📷 스크린샷
<img width="300" alt="image" src="https://user-images.githubusercontent.com/63948884/224558296-1b09dc80-87ba-4a7f-bc8d-16cbd0fcb1c8.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/63948884/224558308-f5ca9581-72db-4353-8799-32a3b7cfe57b.png">
