### PR TITLE
[fix] 에디터 첨부 이미지 최대 너비 제한

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dayjs": "^1.11.7",
     "html-react-parser": "^3.0.12",
     "next": "13.1.6",
+    "quill-image-compress": "^1.2.29",
     "quill-image-resize": "^3.0.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/components/Editor/RichEditor.tsx
+++ b/src/components/Editor/RichEditor.tsx
@@ -1,5 +1,6 @@
 import 'react-quill/dist/quill.snow.css';
 
+import ImageCompress from 'quill-image-compress';
 import ImageResize from 'quill-image-resize';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import React from 'react';
@@ -12,6 +13,7 @@ import { SubTravelogueType } from '@/types/post';
 import { editorModules } from './index';
 
 Quill.register('modules/imageResize', ImageResize);
+Quill.register('modules/imageCompress', ImageCompress);
 
 interface RichEditorType {
   content: ControllerRenderProps<SubTravelogueType, 'content'>;
@@ -64,7 +66,10 @@ const RichEditor = ({ content }: RichEditorType) => {
       imageResize: {
         parchment: Quill.import('parchment'),
         modules: ['Resize', 'DisplaySize'],
-        maxWidth: 293,
+      },
+      imageCompress: {
+        quality: 1,
+        maxWidth: 330,
       },
     }),
     [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4675,6 +4675,13 @@ quill-delta@^4.0.1:
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
 
+quill-image-compress@^1.2.29:
+  version "1.2.29"
+  resolved "https://registry.npmjs.org/quill-image-compress/-/quill-image-compress-1.2.29.tgz#c349712fef6824cb5b38c7e9cc91f8a1c2c36c06"
+  integrity sha512-5EFdMXOumQnEHva79AVE/wfZ+Pd9qGAqE8eelvUFgcI1HQMQNy15wl7th90QEYPj/Lw2+h2hJxxCVXrxpmvj6w==
+  dependencies:
+    quill "^1.3.7"
+
 quill-image-resize@^3.0.9:
   version "3.0.9"
   resolved "https://registry.npmjs.org/quill-image-resize/-/quill-image-resize-3.0.9.tgz#5677fb6257560bff951153ddbdb836758e49f804"


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #130 

## 📝 작업 내용
- [x] 에디터에 첨부하는 이미지의 최대 너비를 제한합니다. 
