### PR TITLE
[feat] 로그인 유도 모달창 전역상태 관리

### DIFF
--- a/src/api/core/helper.ts
+++ b/src/api/core/helper.ts
@@ -1,10 +1,13 @@
 import { InternalAxiosRequestConfig } from 'axios';
 
+import { ACCESS_TOKEN } from '@/constants';
+import { getItem } from '@/utils/storage';
+
 export const insertAccessToken = (config: InternalAxiosRequestConfig) => {
-  const token = localStorage.getItem('accessToken');
+  const token = getItem<string>(ACCESS_TOKEN);
 
   if (token && config.headers) {
-    config.headers['AccessToken'] = `Bearer ${JSON.parse(token)}`;
+    config.headers['AccessToken'] = `Bearer ${token}`;
   }
 
   return config;

--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 
 import { PATH_ROUTER } from '@/constants/path';
+import useAuth from '@/hooks/useAuth';
 import { PathRouterType } from '@/types/common';
 import { getInitialPathName } from '@/utils/helper';
 
@@ -17,8 +18,13 @@ const GNB = () => {
   const [value, setValue] = useState<PathRouterType>(
     getInitialPathName(router.pathname as PathRouterType),
   );
+  const { handleOpenAuthConfirmModal } = useAuth();
 
   const onChangeNavigationRoute = (_: unknown, newValue: PathRouterType) => {
+    if ((newValue === 'add' || newValue === 'profile') && handleOpenAuthConfirmModal()) {
+      return;
+    }
+
     if (value === newValue) {
       return;
     }

--- a/src/components/Login/Local.tsx
+++ b/src/components/Login/Local.tsx
@@ -3,10 +3,12 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React from 'react';
 import { useForm } from 'react-hook-form';
+import { useSetRecoilState } from 'recoil';
 
 import { usePostUserSignIn } from '@/api/hooks/user';
 import { CommonInput } from '@/components/common';
 import { ACCESS_TOKEN } from '@/constants';
+import { isAuthConfirmModalState } from '@/recoil';
 import { User } from '@/types/auth';
 import { setItem } from '@/utils/storage';
 
@@ -25,11 +27,13 @@ const Local = () => {
   });
   const { mutate, error } = usePostUserSignIn();
   const router = useRouter();
+  const setIsSignin = useSetRecoilState(isAuthConfirmModalState);
 
   const onSubmit = (formData: FormState) => {
     mutate(formData, {
       onSuccess: ({ data }) => {
         setItem(ACCESS_TOKEN, data.accessToken);
+        setIsSignin(true);
         router.push('/');
       },
     });

--- a/src/components/Login/Local.tsx
+++ b/src/components/Login/Local.tsx
@@ -6,7 +6,9 @@ import { useForm } from 'react-hook-form';
 
 import { usePostUserSignIn } from '@/api/hooks/user';
 import { CommonInput } from '@/components/common';
+import { ACCESS_TOKEN } from '@/constants';
 import { User } from '@/types/auth';
+import { setItem } from '@/utils/storage';
 
 interface FormState {
   email: string;
@@ -27,7 +29,7 @@ const Local = () => {
   const onSubmit = (formData: FormState) => {
     mutate(formData, {
       onSuccess: ({ data }) => {
-        localStorage.setItem('accessToken', JSON.stringify(data.accessToken));
+        setItem(ACCESS_TOKEN, data.accessToken);
         router.push('/');
       },
     });

--- a/src/components/Login/Local.tsx
+++ b/src/components/Login/Local.tsx
@@ -3,12 +3,11 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React from 'react';
 import { useForm } from 'react-hook-form';
-import { useSetRecoilState } from 'recoil';
 
 import { usePostUserSignIn } from '@/api/hooks/user';
 import { CommonInput } from '@/components/common';
 import { ACCESS_TOKEN } from '@/constants';
-import { isAuthConfirmModalState } from '@/recoil';
+import useAuth from '@/hooks/useAuth';
 import { User } from '@/types/auth';
 import { setItem } from '@/utils/storage';
 
@@ -27,7 +26,7 @@ const Local = () => {
   });
   const { mutate, error } = usePostUserSignIn();
   const router = useRouter();
-  const setIsSignin = useSetRecoilState(isAuthConfirmModalState);
+  const { setIsSignin } = useAuth();
 
   const onSubmit = (formData: FormState) => {
     mutate(formData, {

--- a/src/components/Travelogue/TravelogueFeed.tsx
+++ b/src/components/Travelogue/TravelogueFeed.tsx
@@ -2,21 +2,29 @@ import { Stack } from '@mui/material';
 import { useRouter } from 'next/router';
 
 import { FeedContent, FeedHeader, FeedImage } from '@/components/Travelogue';
+import useAuth from '@/hooks/useAuth';
 import { TravelogueFeedType } from '@/types/travelogue';
 
 const TravelogueFeed = ({ data }: { data: TravelogueFeedType }) => {
   const router = useRouter();
+  const { handleOpenAuthConfirmModal } = useAuth();
+
+  const onClickFeed = () => {
+    if (handleOpenAuthConfirmModal()) {
+      return;
+    }
+
+    router.push({
+      pathname: '/detail',
+      query: { travelogueId: data.travelogueId },
+    });
+  };
 
   return (
     <Stack
       spacing={1.5}
       sx={{ maxWidth: '90%', height: 300, margin: '0 auto', pb: 3, cursor: 'pointer' }}
-      onClick={() =>
-        router.push({
-          pathname: '/detail',
-          query: { travelogueId: data.travelogueId },
-        })
-      }>
+      onClick={onClickFeed}>
       <FeedHeader
         profileImageUrl={data.member.profileImageUrl}
         nickname={data.member.nickname}

--- a/src/components/common/SigninLeadModal.tsx
+++ b/src/components/common/SigninLeadModal.tsx
@@ -2,22 +2,26 @@ import { Error as ErrorIcon } from '@mui/icons-material';
 import { DialogActions, DialogContentText, Typography } from '@mui/material';
 import { Dialog, DialogContent, DialogTitle } from '@mui/material';
 import { useRouter } from 'next/router';
+import { useRecoilState } from 'recoil';
 
 import { CommonButton } from '@/components/common';
+import { isAuthConfirmModalState } from '@/recoil';
 import { flexCenterStyle } from '@/styles/commonStyle';
 
-interface SigninLeadModalProps {
-  open: boolean;
-  handleClickClose: () => void;
-}
-
-const SigninLeadModal = ({ open, handleClickClose }: SigninLeadModalProps) => {
+const SigninLeadModal = () => {
+  const [isAuthConfirmModal, setIsAuthConfirmModal] = useRecoilState(
+    isAuthConfirmModalState,
+  );
   const router = useRouter();
+
+  const onClickClose = () => {
+    setIsAuthConfirmModal(false);
+  };
 
   return (
     <Dialog
-      open={open}
-      onClose={handleClickClose}
+      open={isAuthConfirmModal}
+      onClose={onClickClose}
       PaperProps={{ style: { borderRadius: 12 } }}>
       <DialogTitle className='readable-hidden'>로그인 유도 모달</DialogTitle>
 
@@ -50,12 +54,15 @@ const SigninLeadModal = ({ open, handleClickClose }: SigninLeadModalProps) => {
         <CommonButton
           content='로그인'
           customStyle={buttonStyle}
-          handleClick={() => router.push('/auth/login')}
+          handleClick={() => {
+            router.push('/auth/login');
+            onClickClose();
+          }}
         />
         <CommonButton
           content='취소'
           customStyle={{ ...buttonStyle, bgcolor: 'gray010.main', color: 'dark.main' }}
-          handleClick={() => handleClickClose()}
+          handleClick={onClickClose}
         />
       </DialogActions>
     </Dialog>

--- a/src/components/common/SigninLeadModal.tsx
+++ b/src/components/common/SigninLeadModal.tsx
@@ -2,16 +2,14 @@ import { Error as ErrorIcon } from '@mui/icons-material';
 import { DialogActions, DialogContentText, Typography } from '@mui/material';
 import { Dialog, DialogContent, DialogTitle } from '@mui/material';
 import { useRouter } from 'next/router';
-import { useRecoilState } from 'recoil';
 
 import { CommonButton } from '@/components/common';
-import { isAuthConfirmModalState } from '@/recoil';
+import useAuth from '@/hooks/useAuth';
 import { flexCenterStyle } from '@/styles/commonStyle';
 
 const SigninLeadModal = () => {
-  const [isAuthConfirmModal, setIsAuthConfirmModal] = useRecoilState(
-    isAuthConfirmModalState,
-  );
+  const { isAuthConfirmModal, setIsAuthConfirmModal } = useAuth();
+
   const router = useRouter();
 
   const onClickClose = () => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -295,3 +295,5 @@ export const COUNTRIES: readonly CountryType[] = [
   { code: 'ZM', label: '잠비아', phone: '260' },
   { code: 'ZW', label: '짐바브웨', phone: '263' },
 ];
+
+export const ACCESS_TOKEN = 'ACCESS_TOKEN';

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,28 @@
+import { useRecoilState } from 'recoil';
+
+import { isAuthConfirmModalState, isSigninState } from '@/recoil';
+
+const useAuth = () => {
+  const [isSignin, setIsSignin] = useRecoilState(isSigninState);
+  const [isAuthConfirmModal, setIsAuthConfirmModal] = useRecoilState(
+    isAuthConfirmModalState,
+  );
+
+  const handleOpenAuthConfirmModal = () => {
+    if (!isSignin) {
+      setIsAuthConfirmModal(true);
+      return true;
+    }
+
+    return false;
+  };
+
+  return {
+    setIsSignin,
+    isAuthConfirmModal,
+    setIsAuthConfirmModal,
+    handleOpenAuthConfirmModal,
+  } as const;
+};
+
+export default useAuth;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AppProps } from 'next/app';
 import { RecoilRoot } from 'recoil';
 
+import { SigninLeadModal } from '@/components/common';
 import { GNB } from '@/components/GNB';
 import { Header } from '@/components/Header';
 import { AutoComplete } from '@/components/SearchModal';
@@ -32,6 +33,7 @@ export default function App({ Component, pageProps }: AppProps) {
             </AutoComplete>
             <Component {...pageProps} />
             <GNB />
+            <SigninLeadModal />
           </MobileLayout>
         </RecoilRoot>
       </ThemeProvider>

--- a/src/recoil/index.ts
+++ b/src/recoil/index.ts
@@ -1,7 +1,20 @@
 import { atom } from 'recoil';
 import { v4 } from 'uuid';
 
+import { ACCESS_TOKEN } from '@/constants';
+import { getItem } from '@/utils/storage';
+
 export const isHeaderOpenState = atom({
   key: `isHeaderOpen/${v4()}`,
+  default: false,
+});
+
+export const isSigninState = atom({
+  key: 'IS_SIGNIN',
+  default: Boolean(getItem(ACCESS_TOKEN)),
+});
+
+export const isAuthConfirmModalState = atom({
+  key: 'IS_AUTH_CONFIRM_MODAL',
   default: false,
 });


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #133 

## 📝 작업 내용

- token 상수화 모듈 & 기존 스토리지 상수화 token으로 교채
- 로그인 상태 & 인증 확인 모달 상태 Recoil로 전역관리 구현
- 중복되는 전역상태 로직 custom Hook으로 중복 제거

## 📍 PR Point

- `@/components/GNB.tsx` 컴포넌트 24번째 줄의 조건문이 가독성이 떨어지는 로직이라고 생각이 듭니다. 더 좋은 방법으로 조건문을 변경할 방법이 있을까요?
```ts
  const onChangeNavigationRoute = (_: unknown, newValue: PathRouterType) => {
    if ((newValue === 'add' || newValue === 'profile') && handleOpenAuthConfirmModal()) {
      return;
    }

    if (value === newValue) {
      return;
    }

    setValue(newValue);
    router.push(PATH_ROUTER[newValue]);
  };
```
- 메인 페이지 외에 게시글 작성 페이지(add)와 프로필 페이지(profile)는 로그인된 사용자만이 이용할 수 있는 서비스라서 `handleOpenAuthConfirmModal` 함수로 판별하는 로직입니다. `handleOpenAuthConfirmModal` 함수는 로그인된 상태인지 확인하고 `boolean` 값을 반환합니다.

## 📷 스크린샷
