### PR TITLE
[fix] 잘못된 Travelogue Feed Data 수정

### DIFF
--- a/src/api/travelogue/index.ts
+++ b/src/api/travelogue/index.ts
@@ -6,7 +6,7 @@ import { FilterAxiosProps } from '@/types/filter';
 import { TravelogueFeedType, TravelogueListType } from '@/types/travelogue';
 
 export const getRecentTravelogueList = async (
-  page = 1,
+  page = 0,
 ): Promise<TravelogueFeedType[]> => {
   const response = await http.get(`api/travelogues?&page=${page}`);
 

--- a/src/components/Travelogue/FeedContent.tsx
+++ b/src/components/Travelogue/FeedContent.tsx
@@ -47,7 +47,10 @@ const FeedContent = ({ title, nights, days, totalCost }: FeedContentProps) => {
       </Row>
       <Row justifyContentType='start'>
         <FeedChip chipTitle='기간' chipContent={`${nights}박 ${days}일`} />
-        <FeedChip chipTitle='총 경비' chipContent={String(totalCost)} />
+        <FeedChip
+          chipTitle='총 경비'
+          chipContent={`${totalCost.toLocaleString('ko-KR')}원`}
+        />
       </Row>
     </Stack>
   );


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #144 

## 📝 작업 내용

- 인기 게시글 목록 `page = 0` 으로 수정
- 여행 경비 데이터 단순 숫자에서 KRW 단위로 변경

