### PR TITLE
[design] 프로필 페이지에서 사용자 전용 피드 UI 컴포넌트 구현 

### DIFF
--- a/src/components/Main/PopularFeedList.tsx
+++ b/src/components/Main/PopularFeedList.tsx
@@ -8,7 +8,9 @@ const PopularFeedList = () => {
     return null;
   }
 
-  return <SwipeSlider travelogues={popularTravelogues} fade />;
+  return (
+    <SwipeSlider travelogues={popularTravelogues} title='인기 여행 일지' fade autoplay />
+  );
 };
 
 export default PopularFeedList;

--- a/src/components/Profile/Management.tsx
+++ b/src/components/Profile/Management.tsx
@@ -1,4 +1,4 @@
-import { Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 
 import { useUserInformation } from '@/api/hooks/profile';
 import { CommonButton, ProfileAvatar } from '@/components/common';
@@ -16,25 +16,37 @@ const Management = ({ handleOpenEditModal }: ManagementProps) => {
   return (
     <Stack
       spacing={2}
-      minHeight={350}
+      minHeight={175}
       alignItems='center'
       justifyContent='center'
-      bgcolor='gray005.main'>
-      <ProfileAvatar
-        url={profileImageUrl}
-        size={100}
-        iconSize={5}
-        isLoading={isLoading}
-      />
-      <Typography
-        variant='h2'
-        component='h2'
-        sx={{ font: '1.25rem bold', color: 'dark.main' }}>
-        {nickname}
-      </Typography>
+      bgcolor='white.main'>
+      <Box
+        sx={{
+          display: 'flex',
+          width: '100%',
+          justifyContent: 'start',
+          alignItems: 'center',
+          px: 5,
+          boxSizing: 'border-box',
+          gap: 2.5,
+        }}>
+        <ProfileAvatar
+          url={profileImageUrl}
+          size={75}
+          iconSize={5}
+          isLoading={isLoading}
+        />
+        <Typography
+          variant='h2'
+          component='h2'
+          sx={{ font: '1.25rem bold', color: 'dark.main' }}>
+          {nickname}
+        </Typography>
+      </Box>
+
       <CommonButton
         content='프로필 수정'
-        customStyle={{ height: 40 }}
+        customStyle={{ height: 40, bgcolor: 'blue050.main' }}
         handleClick={handleOpenEditModal}
       />
     </Stack>

--- a/src/components/Profile/TemporarySaveTravelogues.tsx
+++ b/src/components/Profile/TemporarySaveTravelogues.tsx
@@ -1,0 +1,20 @@
+import { Box } from '@mui/material';
+
+import { useGetTemporarySaveTravelogues } from '@/api/hooks/travelogue';
+import { SwipeSlider } from '@/components/common';
+
+const TemporarySaveTravelogues = () => {
+  const { data: travelogues } = useGetTemporarySaveTravelogues();
+
+  if (!travelogues || travelogues.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ width: 414 }}>
+      <SwipeSlider travelogues={travelogues} title='임시 저장 여행 일지' />
+    </Box>
+  );
+};
+
+export default TemporarySaveTravelogues;

--- a/src/components/Profile/TemporarySaveTravelogues.tsx
+++ b/src/components/Profile/TemporarySaveTravelogues.tsx
@@ -12,7 +12,11 @@ const TemporarySaveTravelogues = () => {
 
   return (
     <Box sx={{ width: 414 }}>
-      <SwipeSlider travelogues={travelogues} title='임시 저장 여행 일지' />
+      <SwipeSlider
+        travelogues={travelogues}
+        title='임시 저장 여행 일지'
+        customSx={{ py: 2.5, mb: 5 }}
+      />
     </Box>
   );
 };

--- a/src/components/Profile/WrittenByMeTravelogues.tsx
+++ b/src/components/Profile/WrittenByMeTravelogues.tsx
@@ -12,7 +12,11 @@ const WrittenByMeTravelogues = () => {
 
   return (
     <Box sx={{ width: 414 }}>
-      <SwipeSlider travelogues={travelogues} title='내가 작성한 여행 일지' />
+      <SwipeSlider
+        travelogues={travelogues}
+        title='내가 작성한 여행 일지'
+        customSx={{ py: 2.5 }}
+      />
     </Box>
   );
 };

--- a/src/components/Profile/WrittenByMeTravelogues.tsx
+++ b/src/components/Profile/WrittenByMeTravelogues.tsx
@@ -1,0 +1,20 @@
+import { Box } from '@mui/system';
+
+import { useGetWrittenByMeTravelogues } from '@/api/hooks/travelogue';
+import { SwipeSlider } from '@/components/common';
+
+const WrittenByMeTravelogues = () => {
+  const { data: travelogues } = useGetWrittenByMeTravelogues();
+
+  if (!travelogues || travelogues.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ width: 414 }}>
+      <SwipeSlider travelogues={travelogues} title='내가 작성한 여행 일지' />
+    </Box>
+  );
+};
+
+export default WrittenByMeTravelogues;

--- a/src/components/Profile/index.ts
+++ b/src/components/Profile/index.ts
@@ -3,3 +3,5 @@ export { default as EditDrawer } from './EditDrawer';
 export { default as EditForm } from './EditForm';
 export { default as Management } from './Management';
 export { default as MobileAppBarLayout } from './MobileAppBarLayout';
+export { default as TemporarySaveTravelogues } from './TemporarySaveTravelogues';
+export { default as WrittenByMeTravelogues } from './WrittenByMeTravelogues';

--- a/src/components/common/SwipeSlider.tsx
+++ b/src/components/common/SwipeSlider.tsx
@@ -1,7 +1,7 @@
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
-import { Stack } from '@mui/material';
+import { Stack, SxProps, Theme } from '@mui/material';
 import Slider from 'react-slick';
 
 import { Title } from '@/components/common';
@@ -10,23 +10,33 @@ import { TravelogueFeedType } from '@/types/travelogue';
 
 interface SwipeSliderProps {
   travelogues: TravelogueFeedType[];
+
+  title: string;
+  customSx?: SxProps<Theme>;
   fade?: boolean;
+  autoplay?: boolean;
 }
 
-const SwipeSlider = ({ travelogues, fade = false }: SwipeSliderProps) => {
+const SwipeSlider = ({
+  travelogues,
+  title,
+  customSx,
+  fade = false,
+  autoplay = false,
+}: SwipeSliderProps) => {
   const settings = {
     dots: true,
     infinite: true,
-    fade,
-    autoplay: true,
     autoplaySpeed: 3000,
     arrows: false,
+    fade,
+    autoplay,
   };
 
   return (
-    <Stack component='section' sx={{ p: 5 }}>
+    <Stack component='section' sx={{ p: 5, width: '80%', ...customSx }}>
       <Title bold='bold' fontSize='1.2rem' color='dark.main'>
-        인기 여행 일지
+        {title}
       </Title>
       <Slider {...settings}>
         {travelogues.map((travelogue) => {

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -8,6 +8,7 @@ export { default as ProfileAvatar } from './ProfileAvatar';
 export { default as Row } from './Row';
 export { default as SigninLeadModal } from './SigninLeadModal';
 export { default as SubTitle } from './SubTitle';
+export { default as SwipeSlider } from './SwipeSlider';
 export { default as TemporaryButton } from './TemporaryButton';
 export { default as Title } from './Titlte';
 export { default as Transition } from './Transition';

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -2,7 +2,12 @@ import { Stack } from '@mui/material';
 import { useState } from 'react';
 
 import { useUserInformation } from '@/api/hooks/profile';
-import { ContentLink, EditDrawer, Management } from '@/components/Profile';
+import {
+  EditDrawer,
+  Management,
+  TemporarySaveTravelogues,
+  WrittenByMeTravelogues,
+} from '@/components/Profile';
 
 const Profile = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -15,14 +20,9 @@ const Profile = () => {
   return (
     <Stack>
       <Management handleOpenEditModal={() => setIsOpen(true)} />
-      <Stack alignItems='center'>
-        <ContentLink contentName='내가 작성한 게시물' route='/' iconName='edit' />
-        <ContentLink contentName='내가 북마크한 게시물' route='/' iconName='bookmark' />
-        <ContentLink
-          contentName='임시 저장한 게시글'
-          route='/'
-          iconName='temporarySave'
-        />
+      <Stack alignItems='center' width={414}>
+        <WrittenByMeTravelogues />
+        <TemporarySaveTravelogues />
       </Stack>
       <EditDrawer isOpen={isOpen} handleCloseEditModal={() => setIsOpen(false)} />
     </Stack>


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #162 

## 📝 작업 내용

- SwipeSlider 컴포넌트를 사용해서 자신이 작성한 피드 목록 UI 컴포넌트 디자인
- SwipeSlider 컴포넌트를 사용해서 임시 저장 목록 UI 컴포넌트 디자인
- 추가된 컴포넌트에 적합한 프로필 페이지 레이아웃 재구성

## 📍 PR Point

- 현재 중복이 매우 많은 상태입니다. 리팩터링 기간에 1순위로 리팩터링을 진행해야 합니다.
- SwipeSlider 컴포넌트를 유동적으로 커스텀할 수 있게 변경해야 합니다. 현재는 제가 필요한 설정만 props로 전달하는 임시방편입니다.

## 📷 스크린샷
