### PR TITLE
[fix] Main 페이지 >> 인기 여행 일지 선택하면 항상 마지막 게시글로 이동하는 문제 해결

### DIFF
--- a/src/components/Main/PopularFeedList.tsx
+++ b/src/components/Main/PopularFeedList.tsx
@@ -8,9 +8,7 @@ const PopularFeedList = () => {
     return null;
   }
 
-  return (
-    <SwipeSlider travelogues={popularTravelogues} title='인기 여행 일지' fade autoplay />
-  );
+  return <SwipeSlider travelogues={popularTravelogues} title='인기 여행 일지' autoplay />;
 };
 
 export default PopularFeedList;


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #185 

## 📝 작업 내용

- 스와이프 Fade 효과 제거

## 📍 PR Point
- 임시방편으로 Fade 효과를 제거했지만 Fade 효과를 사용하는 경우가 생길 수 있으니 정확한 원인을 파악하고 수정해야 합니다.

## 📷 스크린샷

https://user-images.githubusercontent.com/57402711/224912097-bc3e5636-251e-4b7f-a378-b3fa5d1ef24b.mov



