### PR TITLE
[feat] Travelogue 목록 조회 API >> 조건에 따라 정렬

### DIFF
--- a/src/api/hooks/travelogue.ts
+++ b/src/api/hooks/travelogue.ts
@@ -10,12 +10,17 @@ import {
   patchTravelogueDetailById,
 } from '@/api/travelogue';
 import { FilterAxiosProps } from '@/types/filter';
-import { TravelogueListType } from '@/types/travelogue';
+import { BaseTravelogueParamsType, TravelogueListType } from '@/types/travelogue';
 
-export const useGetRecentTravelogues = () => {
+export const useGetBaseTravelogueList = ({
+  page = 0,
+  size = 5,
+  sortedType,
+  type,
+}: BaseTravelogueParamsType) => {
   return useQuery({
-    queryKey: ['RECENT_TRAVELOGUES'],
-    queryFn: () => getTypeOfTravelogues({ type: 'recent', page: 0, size: 5 }),
+    queryKey: ['RECENT_TRAVELOGUES', page, size, sortedType, type],
+    queryFn: () => getTypeOfTravelogues({ type, page, size, sortedType }),
   });
 };
 

--- a/src/api/travelogue/index.ts
+++ b/src/api/travelogue/index.ts
@@ -4,19 +4,22 @@ import { baseRequest } from '@/api/core';
 import http from '@/api/core/axiosInstance';
 import { TRAVELOGUE_API_ROUTER } from '@/constants/path';
 import { FilterAxiosProps } from '@/types/filter';
-import { TravelogueFeedType, TravelogueListType } from '@/types/travelogue';
+import {
+  BaseTravelogueParamsType,
+  TravelogueFeedType,
+  TravelogueListType,
+} from '@/types/travelogue';
 
 export const getTypeOfTravelogues = async ({
+  page,
+  size,
   type,
-  page = 0,
-  size = 0,
-}: {
-  page: number;
-  size: number;
-  type: keyof typeof TRAVELOGUE_API_ROUTER;
-}): Promise<TravelogueFeedType[]> => {
+  sortedType,
+}: BaseTravelogueParamsType): Promise<TravelogueFeedType[]> => {
   const response = await http.get<TravelogueListType>(
-    `${TRAVELOGUE_API_ROUTER[type]}?page=${page}&size=${size}`,
+    `${TRAVELOGUE_API_ROUTER[type]}?page=${page}&size=${size}${
+      sortedType ? `&sort=${sortedType}` : ''
+    }`,
   );
 
   return response.data.content;

--- a/src/components/Main/PersonalFeedList.tsx
+++ b/src/components/Main/PersonalFeedList.tsx
@@ -31,9 +31,9 @@ const PersonalFeedList = () => {
       <Title bold='bold' fontSize='1.4rem' color='dark.main' sx={{ ml: '15px' }}>
         추천 여행 일지
       </Title>
-      {personalTravelogues.map((travelogue, index) => (
+      {personalTravelogues.map((travelogue) => (
         <TravelogueFeed
-          key={String(travelogue.travelogueId + index)}
+          key={String(travelogue.travelogueId)}
           data={travelogue}
           isBottomPadding
         />

--- a/src/components/Main/PopularFeedList.tsx
+++ b/src/components/Main/PopularFeedList.tsx
@@ -1,8 +1,13 @@
-import { useGetRecentTravelogues } from '@/api/hooks/travelogue';
+import { useGetBaseTravelogueList } from '@/api/hooks/travelogue';
 import SwipeSlider from '@/components/common/SwipeSlider';
 
 const PopularFeedList = () => {
-  const { data: popularTravelogues } = useGetRecentTravelogues();
+  const { data: popularTravelogues } = useGetBaseTravelogueList({
+    page: 0,
+    size: 5,
+    sortedType: 'viewCount,desc',
+    type: 'recent',
+  });
 
   if (!popularTravelogues || popularTravelogues.length === 0) {
     return null;

--- a/src/types/travelogue.ts
+++ b/src/types/travelogue.ts
@@ -1,3 +1,4 @@
+import { TRAVELOGUE_API_ROUTER } from '@/constants/path';
 import { SubTravelogueDetailType } from '@/types/post';
 
 export interface TravelogueFeedType {
@@ -45,3 +46,10 @@ export interface TravelogueDetailType {
 }
 
 export type TravelInfoTitle = '여행지' | '여행기간' | '여행경비' | '이동수단';
+
+export interface BaseTravelogueParamsType {
+  page: number;
+  size: number;
+  sortedType?: 'viewCount,desc';
+  type: keyof typeof TRAVELOGUE_API_ROUTER;
+}


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #183 

## 📝 작업 내용

- Travelogue 목록 조회 API >> 조건에 따른 정렬 query로 설정(최신, 조회수)

## 📍 PR Point

- 공통으로 사용되는 hoo api(게시글 목록 조회) 로직을 공통화해야 합니다. 현재는 중복된 로직이 많이 존재합니다. `리팩터링 1순위`

