### PR TITLE
[feat] 임시 저장 트래블로그 라우팅

### DIFF
--- a/src/components/Profile/TemporarySaveTravelogues.tsx
+++ b/src/components/Profile/TemporarySaveTravelogues.tsx
@@ -21,6 +21,7 @@ const TemporarySaveTravelogues = () => {
         travelogues={travelogues}
         title={title}
         customSx={{ py: 2.5, mb: 5 }}
+        isTemp={true}
       />
     </Box>
   );

--- a/src/components/Travelogue/TravelogueFeed.tsx
+++ b/src/components/Travelogue/TravelogueFeed.tsx
@@ -4,19 +4,35 @@ import { useRouter } from 'next/router';
 import { FeedContent, FeedHeader, FeedImage } from '@/components/Travelogue';
 import useAuth from '@/hooks/useAuth';
 import { TravelogueFeedType } from '@/types/travelogue';
+import { setItem } from '@/utils/storage';
 
 interface TravelogueFeedProps {
   data: TravelogueFeedType;
   isBottomPadding?: boolean;
+  isTemp?: boolean;
 }
 
-const TravelogueFeed = ({ data, isBottomPadding = false }: TravelogueFeedProps) => {
+const TravelogueFeed = ({
+  data,
+  isBottomPadding = false,
+  isTemp = false,
+}: TravelogueFeedProps) => {
   const router = useRouter();
   const { handleOpenAuthConfirmModal } = useAuth();
 
   const onClickFeed = () => {
     if (handleOpenAuthConfirmModal()) {
       return;
+    }
+
+    if (isTemp) {
+      const { days, travelogueId } = data;
+      const subsId = ['1', '2'];
+      setItem(`temp-data-${travelogueId}`, { days, subsId });
+      router.push({
+        pathname: '/post/first',
+        query: { travelogueId, temp: true },
+      });
     }
 
     router.push({

--- a/src/components/common/SwipeSlider.tsx
+++ b/src/components/common/SwipeSlider.tsx
@@ -14,6 +14,7 @@ interface SwipeSliderProps {
   customSx?: SxProps<Theme>;
   fade?: boolean;
   autoplay?: boolean;
+  isTemp?: boolean;
 }
 
 const SwipeSlider = ({
@@ -22,6 +23,7 @@ const SwipeSlider = ({
   customSx,
   fade = false,
   autoplay = false,
+  isTemp = false,
 }: SwipeSliderProps) => {
   const settings = {
     dots: true,
@@ -39,7 +41,7 @@ const SwipeSlider = ({
       </Title>
       <Slider {...settings}>
         {travelogues.map((travelogue) => (
-          <TravelogueFeed key={String(travelogue.travelogueId)} data={travelogue} />
+          <TravelogueFeed key={String(travelogue.travelogueId)} data={travelogue} isTemp={isTemp} />
         ))}
       </Slider>
     </Stack>


### PR DESCRIPTION
## ⛓ 관련 이슈

- close #192 

## 📝 작업 내용

- [x] 마이페이지에서 임시저장 게시글을 누르면 트래블로그 수정 페이지로 이동하고, 서브 트래블로그를 이어서 작성할 수 있습니다.

## 📍 PR Point

- 현재 트래블로그를 임시저장한 뒤, 서브 트래블로그를 임시저장 하고 발행을 하지 않았을 경우 마이페이지의 임시저장 게시글에서 볼 수 있습니다.
- 해당 게시글을 클릭하면 트래블로그 작성 페이지로 이동하고 수정이 가능합니다.
- 하지만 해당 트래블로그에 딸린 서브 트래블로그에 대한 정보가 없는 상태여서 임시저장된 서브 트래블로그를 보여주지 못하고 있습니다. 
- 정리하자면 현재는 트래블로그'만' 임시저장이 되었을 경우 이어서 서브 트래블로그를 작성하는 것은 가능하지만, 서브 트래블로그까지 임시저장이 되었을 경우 이어서 쓰는 것이 불가능합니다.
- 이는 API에 서브 트래블로그 아이디 배열이 추가된 뒤 수정을 할 예정입니다.  

- 급하게 구현하느라 코드가 더럽습니다. 나중에 리팩토링하겠습니다!


